### PR TITLE
Remove 0.9's "upgrade required" notice due to block versions

### DIFF
--- a/src/core.cpp
+++ b/src/core.cpp
@@ -21,7 +21,7 @@
 
 #include "util.h"
 
-int64_t GetTimeAdjustedValue(int64_t initial_value, int relative_depth)
+int64_t TimeAdjustValueForward(int64_t initial_value, uint32_t distance)
 {
     /* We accept a signed initial_value as input, but perform
      * demurrage calculations on that value's absolute magnitude. */
@@ -81,7 +81,7 @@ int64_t GetTimeAdjustedValue(int64_t initial_value, int relative_depth)
     /* Overflow sensitive fixed point multiply-and-accumulate methods
      * which are used both for the exponentiation to calcuate the
      * demurrage rate, and the final multiply at the end. */
-    uint64_t sum, overflow;
+    uint64_t sum=0, overflow=0;
     #define shift32() do { \
         sum = (overflow << 32) + (sum >> 32); \
         overflow = 0; \
@@ -136,9 +136,8 @@ int64_t GetTimeAdjustedValue(int64_t initial_value, int relative_depth)
              * contribution to the final result are entirely wiped
              * away by truncation are not included. */
 
-            sum = k1;
             overflow = 0;
-            sum *= w0;
+            sum= k1 * w0;
             term(k0 * w1);
             shift32();
             term(k0 * w0);
@@ -188,6 +187,229 @@ int64_t GetTimeAdjustedValue(int64_t initial_value, int relative_depth)
     // assert(result <= MAX_MONEY);
 
     return sign * static_cast<int64_t>(sum);
+}
+
+int64_t TimeAdjustValueReverse(int64_t initial_value, uint32_t distance)
+{
+    /* We accept a signed initial_value as input, but perform
+     * demurrage calculations on that value's absolute magnitude. */
+    const int sign = (initial_value > 0) - (initial_value < 0);
+    const uint64_t value = std::abs(initial_value);
+
+    /* Later on we might return +/- MAX_MONEY in cases of overflow.
+     * The one instance in which this is incorrect behavior is when
+     * the input value is zero, so we must handle that as a special
+     * case first. */
+    if (value == 0)
+        return 0;
+
+    /* A distance of 2^26 blocks and beyond are sufficient to decay
+     * even MAX_MONEY to zero going forward, which in reverse implies
+     * d a single kria would exceed MAX_MONEY. */
+    const int64_t kOverflow = sign * MAX_MONEY;
+    if (distance >= ((uint32_t)1<<26))
+        return kOverflow;
+
+    /* These arrays of pre-generated constants are an exponentiation
+     * ladder of properly calculated 64.64-bit fixed point inverse
+     * demurrage factors for power-of-2 block intervals. Calculating
+     * the the aggregate inverse demurrage factor for the given
+     * distance is a matter of performing fixed point multiplication
+     * of the factors corresponding to the powers of 2 (set bits) in
+     * the binary representation of distance.
+     *
+     * Our lookup table does not go beyond 26 entries because a
+     * distance of 2^26 blocks (the would-be 27th entry) would cause
+     * any input value (except zero) to overflow. */
+    static const uint32_t k32[4*26] = {
+        0x00000000, 0x00000001, 0x00001000, 0x01000010, /* -2^0 = -1 */
+        0x00000000, 0x00000001, 0x00002000, 0x03000040, /* -2^1 = -2 */
+        0x00000000, 0x00000001, 0x00004000, 0x0a000140, /* -2^2 = -4 */
+        0x00000000, 0x00000001, 0x00008000, 0x24000780, /* -2^3 = -8 */
+        0x00000000, 0x00000001, 0x00010000, 0x88003300, /* ... */
+        0x00000000, 0x00000001, 0x00020002, 0x10017600,
+        0x00000000, 0x00000001, 0x00040008, 0x200b2c0b,
+        0x00000000, 0x00000001, 0x00080020, 0x405758b2,
+        0x00000000, 0x00000001, 0x00100080, 0x82b2baeb,
+        0x00000000, 0x00000001, 0x00200201, 0x15760cb0,
+        0x00000000, 0x00000001, 0x00400802, 0xab357b3b,
+        0x00000000, 0x00000001, 0x00802009, 0x5800bbef,
+        0x00000000, 0x00000001, 0x01008032, 0xbd5bcef3,
+        0x00000000, 0x00000001, 0x02020166, 0x20651cee,
+        0x00000000, 0x00000001, 0x04080ad5, 0xdee644e3,
+        0x00000000, 0x00000001, 0x08205643, 0x1a97126a,
+        0x00000000, 0x00000001, 0x1082b600, 0x14af6333,
+        0x00000000, 0x00000001, 0x2216057d, 0x856dd258,
+        0x00000000, 0x00000001, 0x48b5e655, 0x53fde431,
+        0x00000000, 0x00000001, 0xa6129f7a, 0x2b20cd20,
+        0x00000000, 0x00000002, 0xb7e16721, 0x96b730c5,
+        0x00000000, 0x00000007, 0x6399a46e, 0xd2eda481,
+        0x00000000, 0x00000036, 0x99272f73, 0x36391a9f,
+        0x00000000, 0x00000ba4, 0xf827e152, 0x14cd8421,
+        0x00000000, 0x008797a2, 0x510309b9, 0xc64e0d7e,
+        0x000047d1, 0x470253b0, 0x78e38992, 0x14983b4b };
+
+    /* Overflow sensitive fixed point multiply-and-accumulate methods
+     * which are used both for the exponentiation to calcuate the
+     * aggregate demurrage rate, and the final multiply at the end. */
+    uint64_t sum=0, overflow=0;
+    #define shift32() do { \
+        sum = (overflow << 32) + (sum >> 32); \
+        overflow = 0; \
+    } while (0)
+    #define term(_val) do { \
+        const uint64_t val = (_val); \
+        overflow += (sum + val) < sum; \
+        sum += val; \
+    } while (0)
+
+    /* We calculate the aggregate inverse demurrage factor for
+     * distance by raising the per-block rate of 1/(1 - 2^-20) to the
+     * distance'th power. To perform this computation efficiently we
+     * perform N multiplications of a pre-computed exponentiation
+     * ladder, where N is the number of set bits in the binary
+     * representation of distance. */
+
+    /* At the end of this calculation the 64.64-bit fixed-point number
+     * w will contain a representation of the demurrage or inverse
+     * demurrage rate as a quad of 32-bit unsigned words, the most
+     * significant word first. Its initial value is multiplicative
+     * identity, 1.0, for which the fractional bits are zero. */
+    uint32_t w[4] = { 0, 1, 0, 0 };
+
+    /* The first multiplication has the accumulator set to 1.0. So as
+     * an optimization we don't need to perform a term-by-term
+     * multiplication, but can instead just copy the factor into the
+     * accumulator. */
+    bool first = true;
+
+    for (int bit = 0; distance; distance >>= 1, ++bit) {
+        if (distance & 1) {
+            /* w contains the multiplicative identity, so the first
+             * time a bit is set we simply copy the relevant factor
+             * into the accumulator. */
+            if (first) {
+                first = false;
+                w[0] = k32[4*bit];
+                w[1] = k32[4*bit+1];
+                w[2] = k32[4*bit+2];
+                w[3] = k32[4*bit+3];
+                continue;
+            }
+
+            /* Zero-extend the accumulator state and ladder entry as
+             * we will be doing our multiplications in 64-bit to
+             * capture full range and detect overflow. */
+            const uint64_t w0 = w[0];
+            const uint64_t w1 = w[1];
+            const uint64_t w2 = w[2];
+            const uint64_t w3 = w[3];
+            const uint64_t k0 = k32[4*bit];
+            const uint64_t k1 = k32[4*bit+1];
+            const uint64_t k2 = k32[4*bit+2];
+            const uint64_t k3 = k32[4*bit+3];
+
+            /* Carry out the multiplication, term-by-term. Terms which
+             * have no consistently detectible contribution to the
+             * final result due to truncation are not included. */
+
+            overflow = 0;
+            sum= k3 * w2;
+            term(k2 * w3);
+            shift32();
+
+            term(k3 * w1);
+            term(k2 * w2);
+            term(k1 * w3);
+            w[3] = static_cast<uint32_t>(sum);
+            shift32();
+
+            if (bit == 25) {
+                term(k3 * w0);
+                term(k0 * w3);
+            }
+            term(k2 * w1);
+            term(k1 * w2);
+            w[2] = static_cast<uint32_t>(sum);
+            shift32();
+
+            if (bit == 25) {
+                term(k2 * w0);
+                term(k0 * w2);
+            }
+            term(k1 * w1);
+            w[1] = static_cast<uint32_t>(sum);
+            shift32();
+
+            if (bit == 25) {
+                term(k1 * w0);
+                term(k0 * w1);
+            }
+            w[0] = static_cast<uint32_t>(sum);
+
+            /* The above calculation can only possibly overflow on the
+             * very last run through the loop. If there was overflow
+             * the output would necessarily exceed MAX_MONEY and be
+             * clamped so there is no need to proceed further. */
+            if (bit == 25) {
+                shift32();
+                if (sum || w0) {
+                    return kOverflow;
+                }
+            }
+        }
+    }
+
+    /* Now we multiply the original value by the inverse demurrage
+     * factor, in much the same way the fixed point calculations were
+     * performed above, but with fewer terms since value has no
+     * fractional component. */
+    const uint64_t v0 = value >> 32;
+    const uint64_t v1 = static_cast<uint32_t>(value);
+
+    overflow = 0;
+    sum = (v1 * w[3]) >> 32;
+
+    term(v1 * w[2]);
+    term(v0 * w[3]);
+    shift32();
+
+    term(v1 * w[1]);
+    term(v0 * w[2]);
+    const uint64_t r1 = static_cast<uint32_t>(sum);
+    shift32();
+
+    term(v1 * w[0]);
+    term(v0 * w[1]);
+    const uint64_t r0 = static_cast<uint32_t>(sum);
+    shift32();
+
+    #undef term
+    #undef shift32
+
+    /* The final term represents bits 65-128. If this term is
+     * non-zero, or if shift32 left any residual value or overflow, we
+     * know we have exceeded our range. */
+    if (sum || (v0 && w[0])) {
+        return kOverflow;
+    }
+
+    /* Finally we return our calculated result, clamped to never be
+     * more than MAX_MONEY. */
+    int64_t result = (static_cast<int64_t>(r0) << 32) | static_cast<int64_t>(r1);
+    if (result > MAX_MONEY) {
+        return kOverflow;
+    }
+
+    return sign * result;
+}
+
+int64_t GetTimeAdjustedValue(int64_t initial_value, int relative_depth)
+{
+    if (relative_depth < 0)
+        return TimeAdjustValueReverse(initial_value, std::abs(relative_depth));
+    else
+        return TimeAdjustValueForward(initial_value, relative_depth);
 }
 
 std::string COutPoint::ToString() const

--- a/src/core.cpp
+++ b/src/core.cpp
@@ -23,60 +23,60 @@
 
 int64_t GetTimeAdjustedValue(int64_t initial_value, int relative_depth)
 {
+    /* We accept a signed initial_value as input, but perform
+     * demurrage calculations on that value's absolute magnitude. */
     const int sign = (initial_value > 0) - (initial_value < 0);
     const uint64_t value = std::abs(initial_value);
+
+    /* The demurrage rate for an offset of 0 blocks, which is 1.0
+     * exactly, has no representation in 0.64 fixed point. */
+    if (distance == 0)
+        return initial_value;
+    /* A distance of 2^26 blocks and beyond are sufficient to decay
+     * even MAX_MONEY to zero. */
+    if (distance >= ((uint32_t)1<<26))
+        return 0;
 
     /* This array of pre-generated constants is an exponentiation
      * ladder of properly calculated 64-bit fixed point demurrage
      * rates for power-of-2 block intervals. Calculating the actual
-     * demurrage rate for the passed in relative_depth is a matter of
+     * demurrage rate for the passed in distance is a matter of
      * performing fixed point multiplication of the factors
      * corresponding to the powers of 2 (set bits) which make up
-     * relative_depth.
+     * distance.
      *
      * Our lookup table does not go beyond 26 entries because a
-     * relative_depth of 1<<26 (the would-be 27th entry) would cause
-     * even MAX_MONEY (2^53 - 1) to decay to zero. */
+     * distance of 1<<26 (the would-be 27th entry) would cause even
+     * MAX_MONEY (2^53 - 1) to decay to zero. If we are given a
+     * distance value greater than or equal to (1<<26), we simply
+     * return 0LL. */
     static const uint32_t k32[2*26] = {
-        0xfffff000UL, 0x00000000UL, /* 2^0 = 1 */
-        0xffffe000UL, 0x01000000UL, /* 2^1 = 2 */
-        0xffffc000UL, 0x05ffffc0UL, /* 2^2 = 4 */
-        0xffff8000UL, 0x1bfffc80UL, /* 2^3 = 8 */
-        0xffff0000UL, 0x77ffdd00UL, /* ... */
-        0xfffe0001UL, 0xeffeca00UL,
-        0xfffc0007UL, 0xdff5d409UL,
-        0xfff8001fUL, 0xbfaca8a2UL,
-        0xfff0007fUL, 0x7d5d5a6aUL,
-        0xffe001feUL, 0xeacb48a8UL,
-        0xffc007fdUL, 0x55dfda2aUL,
-        0xff801ff6UL, 0xad5499cdUL,
-        0xff007fcdUL, 0x67f98aadUL,
-        0xfe01fe9bUL, 0x74f0943eUL,
-        0xfc07f540UL, 0x767d2a82UL,
-        0xf81fab16UL, 0x3dc15990UL,
-        0xf07d5f65UL, 0xf9604ac9UL,
-        0xe1eb5045UL, 0x80b6ebf7UL,
-        0xc75f7b66UL, 0xa5075defUL,
-        0x9b459576UL, 0x663bbb3eUL,
-        0x5e2d55e7UL, 0x48e27ab4UL,
-        0x22a5531dUL, 0x29a95916UL,
-        0x04b054d7UL, 0xfda49c4dUL,
-        0x0015fc1bUL, 0x85085be9UL,
-        0x000001e3UL, 0x54ca043cUL,
-        0x00000000UL, 0x00039089UL };
-
-    /* This fixed-point method is incapable of calculating "negative"
-     * demurrage rates. */
-    if (relative_depth < 0)
-        return value;
-    /* The demurrage rate for a depth of 0, which is 1.0 exactly, has
-     * no representation in 0.64 fixed point. */
-    if (relative_depth == 0)
-        return value;
-    /* Depth of (1<<26) and beyond are sufficient to decay even
-     * MAX_MONEY to zero. */
-    if (relative_depth >= (1<<26))
-        return 0;
+        0xfffff000, 0x00000000, /* 2^0 = 1 */
+        0xffffe000, 0x01000000, /* 2^1 = 2 */
+        0xffffc000, 0x05ffffc0, /* 2^2 = 4 */
+        0xffff8000, 0x1bfffc80, /* 2^3 = 8 */
+        0xffff0000, 0x77ffdd00, /* ... */
+        0xfffe0001, 0xeffeca00,
+        0xfffc0007, 0xdff5d409,
+        0xfff8001f, 0xbfaca8a2,
+        0xfff0007f, 0x7d5d5a6a,
+        0xffe001fe, 0xeacb48a8,
+        0xffc007fd, 0x55dfda2a,
+        0xff801ff6, 0xad5499cd,
+        0xff007fcd, 0x67f98aad,
+        0xfe01fe9b, 0x74f0943e,
+        0xfc07f540, 0x767d2a82,
+        0xf81fab16, 0x3dc15990,
+        0xf07d5f65, 0xf9604ac9,
+        0xe1eb5045, 0x80b6ebf7,
+        0xc75f7b66, 0xa5075def,
+        0x9b459576, 0x663bbb3e,
+        0x5e2d55e7, 0x48e27ab4,
+        0x22a5531d, 0x29a95916,
+        0x04b054d7, 0xfda49c4d,
+        0x0015fc1b, 0x85085be9,
+        0x000001e3, 0x54ca043c,
+        0x00000000, 0x00039089 };
 
     /* Overflow sensitive fixed point multiply-and-accumulate methods
      * which are used both for the exponentiation to calcuate the
@@ -92,30 +92,38 @@ int64_t GetTimeAdjustedValue(int64_t initial_value, int relative_depth)
         sum += val; \
     } while (0)
 
-    /* We calculate the first 64 fractional bits of the demurrage rate
-     * for relative_depth by raising the per-block rate of (1 - 2^-20)
-     * to the relative_depth power. To perform this computation
-     * efficiently we perform N multiplications of a pre-computed
-     * exponentiation ladder, where N is the number of set bits in the
-     * binary representation of relative_depth. */
+    /* We calculate the first 64 fractional bits of the aggregate
+     * demurrage rate over distance blocks by raising the per-block
+     * rate of (1 - 2^-20) to the distance'th power. To perform this
+     * computation efficiently we perform N multiplications out of a
+     * pre-computed exponentiation ladder, where N is the number of
+     * set bits in the binary representation of distance. */
 
-    /* At the end of this calculation w will contain the first 64 bits
-     * of the demurrage rate as a pair of 32-bit unsigned words, the
-     * most significant word first. Its initial value is
-     * multiplicative identity, 1.0, for which the fractional bits are
-     * zero. */
+    /* At the end of this calculation w will contain the first 64
+     * fractional bits of the demurrage rate as a pair of 32-bit
+     * unsigned words, the most significant word first. Its initial
+     * value is multiplicative identity, 1.0, for which the fractional
+     * bits are zero. */
     uint32_t w[2] = { 0 };
 
     /* The first multiplication has the accumulator set to 1.0, which
-     * is the only time it has a value >= 1. This means that there are
-     * some terms which are non-zero on only the very first
-     * multiplication performed, and since the fractional bits of 1.0
-     * are zero, the other terms that would normally are used are
-     * not. */
+     * is the only time it has a value >= 1. Since we don't store the
+     * non-fractional bits, we need to special-case the first
+     * multiplication. */
     bool first = true;
 
-    for (int bit = 0; relative_depth; relative_depth >>= 1, ++bit) {
-        if (relative_depth & 1) {
+    for (int bit = 0; distance; distance >>= 1, ++bit) {
+        if (distance & 1) {
+            /* The first time through the accumulator has the value
+             * 1.0.  Multiplication by 1.0 is easy--just copy the
+             * value from the table. */
+            if (first) {
+                first = false;
+                w[0] = k32[2*bit];
+                w[1] = k32[2*bit+1];
+                continue;
+            }
+
             /* Zero-extend the accumulator state and ladder entry as
              * we will be doing our multiplications in 64-bit to
              * capture to full range. */
@@ -130,18 +138,13 @@ int64_t GetTimeAdjustedValue(int64_t initial_value, int relative_depth)
 
             sum = k1;
             overflow = 0;
-            if (!first) {
-                sum *= w0;
-                term(k0 * w1);
-                shift32();
-                term(k0 * w0);
-            }
+            sum *= w0;
+            term(k0 * w1);
+            shift32();
+            term(k0 * w0);
             w[1] = static_cast<uint32_t>(sum);
             shift32();
 
-            if (first) {
-                term(k0);
-            }
             w[0] = static_cast<uint32_t>(sum);
 
             /* Debugging check: under no circumstances should it ever
@@ -151,22 +154,20 @@ int64_t GetTimeAdjustedValue(int64_t initial_value, int relative_depth)
              * greater, which shouldn't be possile. */
             // shift32();
             // assert(sum == 0);
-
-            first = false;
         }
     }
 
     /* We now perform an approximately similar multiplication of the
      * final calculated demurrage factor by the passed in value. */
-    const uint64_t v0 = static_cast<uint32_t>(value);
-    const uint64_t v1 = value >> 32;
+    const uint64_t v0 = value >> 32;
+    const uint64_t v1 = static_cast<uint32_t>(value);
 
     overflow = 0;
-    sum = (w[1] * v0) >> 32;
-    term(w[1] * v1);
-    term(w[0] * v0);
-    shift32();
+    sum = (w[1] * v1) >> 32;
+    term(w[1] * v0);
     term(w[0] * v1);
+    shift32();
+    term(w[0] * v0);
 
     #undef term
     #undef shift32
@@ -177,6 +178,14 @@ int64_t GetTimeAdjustedValue(int64_t initial_value, int relative_depth)
      * max(), which should never be possible as the demurrage factor
      * should always be a fractional number less than one. */
     // assert(overflow == 0);
+
+    /* Debugging check: the semantics of time-adjustment are that it
+     * never returns a value with magnitude outside the range of [0,
+     * MAX_MONEY]. But the only way this could happen is if we are
+     * passed a value greater than MAX_MONEY, which is outside the
+     * domain of this function. So we don't need to check for this in
+     * production */
+    // assert(result <= MAX_MONEY);
 
     return sign * static_cast<int64_t>(sum);
 }

--- a/src/core.cpp
+++ b/src/core.cpp
@@ -168,6 +168,9 @@ int64_t GetTimeAdjustedValue(int64_t initial_value, int relative_depth)
     shift32();
     term(w[0] * v1);
 
+    #undef term
+    #undef shift32
+
     /* Debugging check: having the overflow bit set at this point
      * would indicate that the demurrage calculation has resulted in
      * an amount that is greater than std::numeric_limits<int64_t>::

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2100,24 +2100,6 @@ void static UpdateTip(CBlockIndex *pindexNew) {
       chainActive.Tip()->GetBlockHash().ToString(), chainActive.Height(), log(chainActive.Tip()->nChainWork.getdouble())/log(2.0), (unsigned long)chainActive.Tip()->nChainTx,
       DateTimeStrFormat("%Y-%m-%d %H:%M:%S", chainActive.Tip()->GetBlockTime()),
       Checkpoints::GuessVerificationProgress(chainActive.Tip()));
-
-    // Check the version of the last 100 blocks to see if we need to upgrade:
-    if (!fIsInitialDownload)
-    {
-        int nUpgraded = 0;
-        const CBlockIndex* pindex = chainActive.Tip();
-        for (int i = 0; i < 100 && pindex != NULL; i++)
-        {
-            if (pindex->nVersion > CBlock::CURRENT_VERSION)
-                ++nUpgraded;
-            pindex = pindex->pprev;
-        }
-        if (nUpgraded > 0)
-            LogPrintf("SetBestChain: %d of last 100 blocks above version %d\n", nUpgraded, (int)CBlock::CURRENT_VERSION);
-        if (nUpgraded > 100/2)
-            // strMiscWarning is read by GetWarnings(), called by Qt and the JSON-RPC code to warn the user:
-            strMiscWarning = _("Warning: This version is obsolete, upgrade required!");
-    }
 }
 
 // Disconnect chainActive's tip.

--- a/src/qt/freicoinstrings.cpp
+++ b/src/qt/freicoinstrings.cpp
@@ -273,7 +273,6 @@ QT_TRANSLATE_NOOP("freicoin-core", "Wallet needed to be rewritten: restart Freic
 QT_TRANSLATE_NOOP("freicoin-core", "Wallet options:"),
 QT_TRANSLATE_NOOP("freicoin-core", "Warning"),
 QT_TRANSLATE_NOOP("freicoin-core", "Warning: Deprecated argument -debugnet ignored, use -debug=net"),
-QT_TRANSLATE_NOOP("freicoin-core", "Warning: This version is obsolete, upgrade required!"),
 QT_TRANSLATE_NOOP("freicoin-core", "You need to rebuild the database using -reindex to change -txindex"),
 QT_TRANSLATE_NOOP("freicoin-core", "Zapping all transactions from wallet..."),
 QT_TRANSLATE_NOOP("freicoin-core", "on startup"),

--- a/src/qt/locale/freicoin_en.ts
+++ b/src/qt/locale/freicoin_en.ts
@@ -4096,11 +4096,6 @@ for example: alertnotify=echo %%s | mail -s &quot;Freicoin Alert&quot; admin@foo
     </message>
     <message>
         <location line="+2"/>
-        <source>Warning: This version is obsolete, upgrade required!</source>
-        <translation>Warning: This version is obsolete, upgrade required!</translation>
-    </message>
-    <message>
-        <location line="+2"/>
         <source>Zapping all transactions from wallet...</source>
         <translation type="unfinished"></translation>
     </message>


### PR DESCRIPTION
Do not warn that an upgrade is required when unrecognized block versions have been observed.
    
This is an necessary consequence of the use of BIP8-like version bits for soft-fork deployments. Remove this commit when rebasing to an upstream version that supports version-bits deployment and able to determine if the client is outdated based on unrecognized version bits flags.

Fixes #21 .