### PR TITLE
[CheckSig] Add SCRIPT_VERIFY_REQUIRE_VALID_SIGS flag and make standard

### DIFF
--- a/src/policy/policy.h
+++ b/src/policy/policy.h
@@ -50,6 +50,7 @@ static const unsigned int STANDARD_SCRIPT_VERIFY_FLAGS = MANDATORY_SCRIPT_VERIFY
                                                          SCRIPT_VERIFY_DERSIG |
                                                          SCRIPT_VERIFY_STRICTENC |
                                                          SCRIPT_VERIFY_MINIMALDATA |
+                                                         SCRIPT_VERIFY_REQUIRE_VALID_SIGS |
                                                          SCRIPT_VERIFY_DISCOURAGE_UPGRADABLE_NOPS |
                                                          SCRIPT_VERIFY_CLEANSTACK;
 

--- a/src/script/script_error.cpp
+++ b/src/script/script_error.cpp
@@ -77,6 +77,10 @@ const char* ScriptErrorString(const ScriptError serror)
             return "Non-canonical signature: S value is unnecessarily high";
         case SCRIPT_ERR_SIG_NULLDUMMY:
             return "Dummy CHECKMULTISIG argument must be zero";
+        case SCRIPT_ERR_MULTISIG_HINT:
+            return "Incorrect or invalid hint provided in CHECKMULTISIG's last argument";
+        case SCRIPT_ERR_FAILED_SIGNATURE_CHECK:
+            return "Failed signature check with non-empty signature argument";
         case SCRIPT_ERR_DISCOURAGE_UPGRADABLE_NOPS:
             return "NOPx reserved for soft-fork upgrades";
         case SCRIPT_ERR_PUBKEYTYPE:

--- a/src/script/script_error.h
+++ b/src/script/script_error.h
@@ -66,6 +66,10 @@ typedef enum ScriptError_t
     /* softfork safeness */
     SCRIPT_ERR_DISCOURAGE_UPGRADABLE_NOPS,
 
+    /* require valid signatures */
+    SCRIPT_ERR_MULTISIG_HINT,
+    SCRIPT_ERR_FAILED_SIGNATURE_CHECK,
+
     SCRIPT_ERR_ERROR_COUNT
 } ScriptError;
 

--- a/src/script/sign.cpp
+++ b/src/script/sign.cpp
@@ -164,8 +164,14 @@ bool SignSignature(const CKeyStore &keystore, const CTransaction& txFrom, CMutab
 static CScript PushAll(const vector<valtype>& values)
 {
     CScript result;
-    BOOST_FOREACH(const valtype& v, values)
-        result << v;
+    BOOST_FOREACH(const valtype& v, values) {
+        if ((v.size() == 1) && (v[0] == 0x81))
+            result << OP_1NEGATE;
+        else if ((v.size() == 1) && ((1 <= v[0]) && (v[0] <= 16)))
+            result << static_cast<opcodetype>(OP_1 + (v[0] - 1));
+        else
+            result << v;
+    }
     return result;
 }
 

--- a/src/test/multisig_tests.cpp
+++ b/src/test/multisig_tests.cpp
@@ -41,12 +41,15 @@ typedef vector<unsigned char> valtype;
 BOOST_FIXTURE_TEST_SUITE(multisig_tests, BasicTestingSetup)
 
 CScript
-sign_multisig(CScript scriptPubKey, vector<CKey> keys, CTransaction transaction, int whichIn)
+sign_multisig(CScript scriptPubKey, vector<CKey> keys, int64_t hint, CTransaction transaction, int whichIn)
 {
     uint256 hash = SignatureHash(scriptPubKey, transaction, whichIn, SIGHASH_ALL);
 
     CScript result;
-    result << OP_0; // CHECKMULTISIG bug workaround
+    // Real signing code should use the MultiSigHint class to generate
+    // this value. We push a serialized integer representation only as
+    // part of the test plan for that code.
+    result << hint;
     BOOST_FOREACH(const CKey &key, keys)
     {
         vector<unsigned char> vchSig;
@@ -60,6 +63,8 @@ sign_multisig(CScript scriptPubKey, vector<CKey> keys, CTransaction transaction,
 BOOST_AUTO_TEST_CASE(multisig_verify)
 {
     unsigned int flags = SCRIPT_VERIFY_P2SH | SCRIPT_VERIFY_STRICTENC;
+    unsigned int nulldummy_flags = flags | SCRIPT_VERIFY_NULLDUMMY;
+    unsigned int validsigs_flags = flags | SCRIPT_VERIFY_REQUIRE_VALID_SIGS;
 
     ScriptError err;
     CKey key[4];
@@ -97,43 +102,107 @@ BOOST_AUTO_TEST_CASE(multisig_verify)
     // Test a AND b:
     keys.assign(1,key[0]);
     keys.push_back(key[1]);
-    s = sign_multisig(a_and_b, keys, txTo[0], 0);
+    s = sign_multisig(a_and_b, keys, 0, txTo[0], 0);
     BOOST_CHECK(VerifyScript(s, a_and_b, flags, MutableTransactionSignatureChecker(&txTo[0], 0), &err));
+    BOOST_CHECK_MESSAGE(err == SCRIPT_ERR_OK, ScriptErrorString(err));
+    BOOST_CHECK(VerifyScript(s, a_and_b, nulldummy_flags, MutableTransactionSignatureChecker(&txTo[0], 0), &err));
+    BOOST_CHECK_MESSAGE(err == SCRIPT_ERR_OK, ScriptErrorString(err));
+    BOOST_CHECK(VerifyScript(s, a_and_b, validsigs_flags, MutableTransactionSignatureChecker(&txTo[0], 0), &err));
     BOOST_CHECK_MESSAGE(err == SCRIPT_ERR_OK, ScriptErrorString(err));
 
     for (int i = 0; i < 4; i++)
     {
         keys.assign(1,key[i]);
-        s = sign_multisig(a_and_b, keys, txTo[0], 0);
+        s = sign_multisig(a_and_b, keys, 0, txTo[0], 0);
         BOOST_CHECK_MESSAGE(!VerifyScript(s, a_and_b, flags, MutableTransactionSignatureChecker(&txTo[0], 0), &err), strprintf("a&b 1: %d", i));
+        BOOST_CHECK_MESSAGE(err == SCRIPT_ERR_INVALID_STACK_OPERATION, ScriptErrorString(err));
+        BOOST_CHECK_MESSAGE(!VerifyScript(s, a_and_b, nulldummy_flags, MutableTransactionSignatureChecker(&txTo[0], 0), &err), strprintf("a&b 1: %d", i));
+        BOOST_CHECK_MESSAGE(err == SCRIPT_ERR_INVALID_STACK_OPERATION, ScriptErrorString(err));
+        BOOST_CHECK_MESSAGE(!VerifyScript(s, a_and_b, validsigs_flags, MutableTransactionSignatureChecker(&txTo[0], 0), &err), strprintf("a&b 1: %d", i));
+        BOOST_CHECK_MESSAGE(err == SCRIPT_ERR_INVALID_STACK_OPERATION, ScriptErrorString(err));
+        s = sign_multisig(a_and_b, keys, 1, txTo[0], 0);
+        BOOST_CHECK_MESSAGE(!VerifyScript(s, a_and_b, flags, MutableTransactionSignatureChecker(&txTo[0], 0), &err), strprintf("a&b 3: %d", i));
+        BOOST_CHECK_MESSAGE(err == SCRIPT_ERR_INVALID_STACK_OPERATION, ScriptErrorString(err));
+        BOOST_CHECK_MESSAGE(!VerifyScript(s, a_and_b, nulldummy_flags, MutableTransactionSignatureChecker(&txTo[0], 0), &err), strprintf("a&b 3: %d", i));
+        BOOST_CHECK_MESSAGE(err == SCRIPT_ERR_INVALID_STACK_OPERATION, ScriptErrorString(err));
+        BOOST_CHECK_MESSAGE(!VerifyScript(s, a_and_b, validsigs_flags, MutableTransactionSignatureChecker(&txTo[0], 0), &err), strprintf("a&b 3: %d", i));
         BOOST_CHECK_MESSAGE(err == SCRIPT_ERR_INVALID_STACK_OPERATION, ScriptErrorString(err));
 
         keys.assign(1,key[1]);
         keys.push_back(key[i]);
-        s = sign_multisig(a_and_b, keys, txTo[0], 0);
+        s = sign_multisig(a_and_b, keys, 0, txTo[0], 0);
         BOOST_CHECK_MESSAGE(!VerifyScript(s, a_and_b, flags, MutableTransactionSignatureChecker(&txTo[0], 0), &err), strprintf("a&b 2: %d", i));
         BOOST_CHECK_MESSAGE(err == SCRIPT_ERR_EVAL_FALSE, ScriptErrorString(err));
+        BOOST_CHECK_MESSAGE(!VerifyScript(s, a_and_b, nulldummy_flags, MutableTransactionSignatureChecker(&txTo[0], 0), &err), strprintf("a&b 2: %d", i));
+        BOOST_CHECK_MESSAGE(err == SCRIPT_ERR_EVAL_FALSE, ScriptErrorString(err));
+        BOOST_CHECK_MESSAGE(!VerifyScript(s, a_and_b, validsigs_flags, MutableTransactionSignatureChecker(&txTo[0], 0), &err), strprintf("a&b 2: %d", i));
+        BOOST_CHECK_MESSAGE(err == SCRIPT_ERR_FAILED_SIGNATURE_CHECK, ScriptErrorString(err));
+        for (int j = 1; j < 5; ++j) {
+            s = sign_multisig(a_and_b, keys, j, txTo[0], 0);
+            BOOST_CHECK_MESSAGE(!VerifyScript(s, a_and_b, flags, MutableTransactionSignatureChecker(&txTo[0], 0), &err), strprintf("a&b 4: %d", i));
+            BOOST_CHECK_MESSAGE(err == SCRIPT_ERR_EVAL_FALSE, ScriptErrorString(err));
+            BOOST_CHECK_MESSAGE(!VerifyScript(s, a_and_b, nulldummy_flags, MutableTransactionSignatureChecker(&txTo[0], 0), &err), strprintf("a&b 4: %d", i));
+            BOOST_CHECK_MESSAGE(err == SCRIPT_ERR_SIG_NULLDUMMY, ScriptErrorString(err));
+            BOOST_CHECK_MESSAGE(!VerifyScript(s, a_and_b, validsigs_flags, MutableTransactionSignatureChecker(&txTo[0], 0), &err), strprintf("a&b 4: %d", i));
+            BOOST_CHECK_MESSAGE(err == SCRIPT_ERR_MULTISIG_HINT, ScriptErrorString(err));
+        }
     }
 
     // Test a OR b:
     for (int i = 0; i < 4; i++)
     {
         keys.assign(1,key[i]);
-        s = sign_multisig(a_or_b, keys, txTo[1], 0);
+        s = sign_multisig(a_or_b, keys, 0, txTo[1], 0);
         if (i == 0 || i == 1)
         {
             BOOST_CHECK_MESSAGE(VerifyScript(s, a_or_b, flags, MutableTransactionSignatureChecker(&txTo[1], 0), &err), strprintf("a|b: %d", i));
             BOOST_CHECK_MESSAGE(err == SCRIPT_ERR_OK, ScriptErrorString(err));
+            BOOST_CHECK_MESSAGE(VerifyScript(s, a_or_b, nulldummy_flags, MutableTransactionSignatureChecker(&txTo[1], 0), &err), strprintf("a|b 1: %d", i));
+            BOOST_CHECK_MESSAGE(err == SCRIPT_ERR_OK, ScriptErrorString(err));
+            BOOST_CHECK_MESSAGE(!VerifyScript(s, a_or_b, validsigs_flags, MutableTransactionSignatureChecker(&txTo[1], 0), &err), strprintf("a|b 1: %d", i));
+            BOOST_CHECK_MESSAGE(err == SCRIPT_ERR_MULTISIG_HINT, ScriptErrorString(err));
         }
         else
         {
             BOOST_CHECK_MESSAGE(!VerifyScript(s, a_or_b, flags, MutableTransactionSignatureChecker(&txTo[1], 0), &err), strprintf("a|b: %d", i));
             BOOST_CHECK_MESSAGE(err == SCRIPT_ERR_EVAL_FALSE, ScriptErrorString(err));
+            BOOST_CHECK_MESSAGE(!VerifyScript(s, a_or_b, nulldummy_flags, MutableTransactionSignatureChecker(&txTo[1], 0), &err), strprintf("a|b 2: %d", i));
+            BOOST_CHECK_MESSAGE(err == SCRIPT_ERR_EVAL_FALSE, ScriptErrorString(err));
+            BOOST_CHECK_MESSAGE(!VerifyScript(s, a_or_b, validsigs_flags, MutableTransactionSignatureChecker(&txTo[1], 0), &err), strprintf("a|b 2: %d", i));
+            BOOST_CHECK_MESSAGE(err == SCRIPT_ERR_MULTISIG_HINT, ScriptErrorString(err));
+        }
+        int hint = 1 + (i%2);
+        s = sign_multisig(a_or_b, keys, hint, txTo[1], 0);
+        if (i == 0 || i == 1)
+        {
+            BOOST_CHECK_MESSAGE(VerifyScript(s, a_or_b, flags, MutableTransactionSignatureChecker(&txTo[1], 0), &err), strprintf("a|b 3: %d", i));
+            BOOST_CHECK_MESSAGE(err == SCRIPT_ERR_OK, ScriptErrorString(err));
+            BOOST_CHECK_MESSAGE(!VerifyScript(s, a_or_b, nulldummy_flags, MutableTransactionSignatureChecker(&txTo[1], 0), &err), strprintf("a|b 3: %d", i));
+            BOOST_CHECK_MESSAGE(err == SCRIPT_ERR_SIG_NULLDUMMY, ScriptErrorString(err));
+            BOOST_CHECK_MESSAGE(VerifyScript(s, a_or_b, validsigs_flags, MutableTransactionSignatureChecker(&txTo[1], 0), &err), strprintf("a|b 3: %d", i));
+            BOOST_CHECK_MESSAGE(err == SCRIPT_ERR_OK, ScriptErrorString(err));
+        }
+        else
+        {
+            BOOST_CHECK_MESSAGE(!VerifyScript(s, a_or_b, flags, MutableTransactionSignatureChecker(&txTo[1], 0), &err), strprintf("a|b 4: %d", i));
+            BOOST_CHECK_MESSAGE(err == SCRIPT_ERR_EVAL_FALSE, ScriptErrorString(err));
+            BOOST_CHECK_MESSAGE(!VerifyScript(s, a_or_b, nulldummy_flags, MutableTransactionSignatureChecker(&txTo[1], 0), &err), strprintf("a|b 4: %d", i));
+            BOOST_CHECK_MESSAGE(err == SCRIPT_ERR_SIG_NULLDUMMY, ScriptErrorString(err));
+            BOOST_CHECK_MESSAGE(!VerifyScript(s, a_or_b, validsigs_flags, MutableTransactionSignatureChecker(&txTo[1], 0), &err), strprintf("a|b 4: %d", i));
+            BOOST_CHECK_MESSAGE(err == SCRIPT_ERR_FAILED_SIGNATURE_CHECK, ScriptErrorString(err));
         }
     }
     s.clear();
     s << OP_0 << OP_1;
     BOOST_CHECK(!VerifyScript(s, a_or_b, flags, MutableTransactionSignatureChecker(&txTo[1], 0), &err));
+    BOOST_CHECK_MESSAGE(err == SCRIPT_ERR_SIG_DER, ScriptErrorString(err));
+    BOOST_CHECK(!VerifyScript(s, a_or_b, nulldummy_flags, MutableTransactionSignatureChecker(&txTo[1], 0), &err));
+    BOOST_CHECK_MESSAGE(err == SCRIPT_ERR_SIG_DER, ScriptErrorString(err));
+    BOOST_CHECK(!VerifyScript(s, a_or_b, validsigs_flags, MutableTransactionSignatureChecker(&txTo[1], 0), &err));
+    BOOST_CHECK_MESSAGE(err == SCRIPT_ERR_MULTISIG_HINT, ScriptErrorString(err));
+    s.clear();
+    s << OP_1 << OP_1;
+    BOOST_CHECK(!VerifyScript(s, a_or_b, validsigs_flags, MutableTransactionSignatureChecker(&txTo[1], 0), &err));
     BOOST_CHECK_MESSAGE(err == SCRIPT_ERR_SIG_DER, ScriptErrorString(err));
 
 
@@ -142,16 +211,48 @@ BOOST_AUTO_TEST_CASE(multisig_verify)
         {
             keys.assign(1,key[i]);
             keys.push_back(key[j]);
-            s = sign_multisig(escrow, keys, txTo[2], 0);
+            s = sign_multisig(escrow, keys, 0, txTo[2], 0);
             if (i < j && i < 3 && j < 3)
             {
                 BOOST_CHECK_MESSAGE(VerifyScript(s, escrow, flags, MutableTransactionSignatureChecker(&txTo[2], 0), &err), strprintf("escrow 1: %d %d", i, j));
                 BOOST_CHECK_MESSAGE(err == SCRIPT_ERR_OK, ScriptErrorString(err));
+                BOOST_CHECK_MESSAGE(VerifyScript(s, escrow, nulldummy_flags, MutableTransactionSignatureChecker(&txTo[2], 0), &err), strprintf("escrow 1: %d %d", i, j));
+                BOOST_CHECK_MESSAGE(err == SCRIPT_ERR_OK, ScriptErrorString(err));
+                BOOST_CHECK_MESSAGE(!VerifyScript(s, escrow, validsigs_flags, MutableTransactionSignatureChecker(&txTo[2], 0), &err), strprintf("escrow 1: %d %d", i, j));
+                BOOST_CHECK_MESSAGE(err == SCRIPT_ERR_MULTISIG_HINT, ScriptErrorString(err));
             }
             else
             {
                 BOOST_CHECK_MESSAGE(!VerifyScript(s, escrow, flags, MutableTransactionSignatureChecker(&txTo[2], 0), &err), strprintf("escrow 2: %d %d", i, j));
                 BOOST_CHECK_MESSAGE(err == SCRIPT_ERR_EVAL_FALSE, ScriptErrorString(err));
+                BOOST_CHECK_MESSAGE(!VerifyScript(s, escrow, nulldummy_flags, MutableTransactionSignatureChecker(&txTo[2], 0), &err), strprintf("escrow 2: %d %d", i, j));
+                BOOST_CHECK_MESSAGE(err == SCRIPT_ERR_EVAL_FALSE, ScriptErrorString(err));
+                BOOST_CHECK_MESSAGE(!VerifyScript(s, escrow, validsigs_flags, MutableTransactionSignatureChecker(&txTo[2], 0), &err), strprintf("escrow 2: %d %d", i, j));
+                BOOST_CHECK_MESSAGE(err == SCRIPT_ERR_MULTISIG_HINT, ScriptErrorString(err));
+            }
+            int hint = 7 & ~((1 << (2-(i%3))) | (1 << (2-(j%3))));
+            s = sign_multisig(escrow, keys, hint, txTo[2], 0);
+            if (i < j && i < 3 && j < 3)
+            {
+                BOOST_CHECK_MESSAGE(VerifyScript(s, escrow, flags, MutableTransactionSignatureChecker(&txTo[2], 0), &err), strprintf("escrow 3: %d %d", i, j));
+                BOOST_CHECK_MESSAGE(err == SCRIPT_ERR_OK, ScriptErrorString(err));
+                BOOST_CHECK_MESSAGE(!VerifyScript(s, escrow, nulldummy_flags, MutableTransactionSignatureChecker(&txTo[2], 0), &err), strprintf("escrow 3: %d %d", i, j));
+                BOOST_CHECK_MESSAGE(err == SCRIPT_ERR_SIG_NULLDUMMY, ScriptErrorString(err));
+                BOOST_CHECK_MESSAGE(VerifyScript(s, escrow, validsigs_flags, MutableTransactionSignatureChecker(&txTo[2], 0), &err), strprintf("escrow 3: %d %d", i, j));
+                BOOST_CHECK_MESSAGE(err == SCRIPT_ERR_OK, ScriptErrorString(err));
+            }
+            else
+            {
+                BOOST_CHECK_MESSAGE(!VerifyScript(s, escrow, flags, MutableTransactionSignatureChecker(&txTo[2], 0), &err), strprintf("escrow 4: %d %d", i, j));
+                BOOST_CHECK_MESSAGE(err == SCRIPT_ERR_EVAL_FALSE, ScriptErrorString(err));
+                BOOST_CHECK_MESSAGE(!VerifyScript(s, escrow, nulldummy_flags, MutableTransactionSignatureChecker(&txTo[2], 0), &err), strprintf("escrow 4: %d %d", i, j));
+                BOOST_CHECK_MESSAGE(err == SCRIPT_ERR_SIG_NULLDUMMY, ScriptErrorString(err));
+                BOOST_CHECK_MESSAGE(!VerifyScript(s, escrow, validsigs_flags, MutableTransactionSignatureChecker(&txTo[2], 0), &err), strprintf("escrow 4: %d %d", i, j));
+                if ((i%3) == (j%3)) {
+                    BOOST_CHECK_MESSAGE(err == SCRIPT_ERR_MULTISIG_HINT, ScriptErrorString(err));
+                } else {
+                    BOOST_CHECK_MESSAGE(err == SCRIPT_ERR_FAILED_SIGNATURE_CHECK, ScriptErrorString(err));
+                }
             }
         }
 }

--- a/src/test/script_tests.cpp
+++ b/src/test/script_tests.cpp
@@ -23,6 +23,7 @@
 #include "core_io.h"
 #include "key.h"
 #include "keystore.h"
+#include "policy/policy.h"
 #include "script/script.h"
 #include "script/script_error.h"
 #include "script/sign.h"
@@ -975,33 +976,101 @@ BOOST_AUTO_TEST_CASE(script_combineSigs)
     sig3.push_back(SIGHASH_SINGLE);
 
     // Not fussy about order (or even existence) of placeholders or signatures:
-    CScript partial1a = CScript() << OP_0 << sig1 << OP_0;
-    CScript partial1b = CScript() << OP_0 << OP_0 << sig1;
-    CScript partial2a = CScript() << OP_0 << sig2;
-    CScript partial2b = CScript() << sig2 << OP_0;
-    CScript partial3a = CScript() << sig3;
-    CScript partial3b = CScript() << OP_0 << OP_0 << sig3;
-    CScript partial3c = CScript() << OP_0 << sig3 << OP_0;
-    CScript complete12 = CScript() << OP_0 << sig1 << sig2;
-    CScript complete13 = CScript() << OP_0 << sig1 << sig3;
-    CScript complete23 = CScript() << OP_0 << sig2 << sig3;
+    static const CScript expected[1 << 3] = {
+        CScript() << OP_7 << OP_0 << OP_0,
+        CScript() << OP_3 << sig1 << OP_0,
+        CScript() << OP_5 << sig2 << OP_0,
+        CScript() << OP_1 << sig1 << sig2,
+        CScript() << OP_6 << sig3 << OP_0,
+        CScript() << OP_2 << sig1 << sig3,
+        CScript() << OP_4 << sig2 << sig3,
+        CScript() << OP_1 << sig1 << sig2,
+    };
 
-    combined = CombineSignatures(scriptPubKey, txTo, 0, partial1a, partial1b);
-    BOOST_CHECK(combined == partial1a);
-    combined = CombineSignatures(scriptPubKey, txTo, 0, partial1a, partial2a);
-    BOOST_CHECK(combined == complete12);
-    combined = CombineSignatures(scriptPubKey, txTo, 0, partial2a, partial1a);
-    BOOST_CHECK(combined == complete12);
-    combined = CombineSignatures(scriptPubKey, txTo, 0, partial1b, partial2b);
-    BOOST_CHECK(combined == complete12);
-    combined = CombineSignatures(scriptPubKey, txTo, 0, partial3b, partial1b);
-    BOOST_CHECK(combined == complete13);
-    combined = CombineSignatures(scriptPubKey, txTo, 0, partial2a, partial3a);
-    BOOST_CHECK(combined == complete23);
-    combined = CombineSignatures(scriptPubKey, txTo, 0, partial3b, partial2b);
-    BOOST_CHECK(combined == complete23);
-    combined = CombineSignatures(scriptPubKey, txTo, 0, partial3b, partial3a);
-    BOOST_CHECK(combined == partial3c);
+    ScriptError err;
+    for (std::size_t i = 0; i < 3; ++i) {
+        for (std::size_t j = 0; j < 3; ++j) {
+            int which = (1 << i) | (1 << j);
+            if (i == j) {
+                BOOST_CHECK(!VerifyScript(expected[which], scriptPubKey, STANDARD_SCRIPT_VERIFY_FLAGS, MutableTransactionSignatureChecker(&txTo, 0), &err));
+                BOOST_CHECK_MESSAGE(err == SCRIPT_ERR_FAILED_SIGNATURE_CHECK, ScriptErrorString(err));
+            } else {
+                BOOST_CHECK(VerifyScript(expected[which], scriptPubKey, STANDARD_SCRIPT_VERIFY_FLAGS, MutableTransactionSignatureChecker(&txTo, 0), &err));
+                BOOST_CHECK_MESSAGE(err == SCRIPT_ERR_OK, ScriptErrorString(err));
+            }
+        }
+    }
+
+    static const std::pair<int, CScript> partials[] = {
+        std::make_pair(0, CScript() << OP_0 << OP_0 << OP_0),
+        std::make_pair(0, CScript() << OP_0 << OP_0),
+        std::make_pair(0, CScript() << OP_0),
+        std::make_pair(0, CScript()),
+        std::make_pair(1, CScript() << OP_0 << OP_0 << sig1),
+        std::make_pair(1, CScript() << OP_0 << sig1 << OP_0),
+        std::make_pair(1, CScript() << sig1 << OP_0 << OP_0),
+        std::make_pair(1, CScript() << OP_0 << sig1),
+        std::make_pair(1, CScript() << sig1 << OP_0),
+        std::make_pair(1, CScript() << sig1),
+        std::make_pair(2, CScript() << OP_0 << OP_0 << sig2),
+        std::make_pair(2, CScript() << OP_0 << sig2 << OP_0),
+        std::make_pair(2, CScript() << sig2 << OP_0 << OP_0),
+        std::make_pair(2, CScript() << OP_0 << sig2),
+        std::make_pair(2, CScript() << sig2 << OP_0),
+        std::make_pair(2, CScript() << sig2),
+        std::make_pair(3, CScript() << OP_0 << sig1 << sig2),
+        std::make_pair(3, CScript() << OP_0 << sig2 << sig1),
+        std::make_pair(3, CScript() << sig1 << OP_0 << sig2),
+        std::make_pair(3, CScript() << sig2 << OP_0 << sig1),
+        std::make_pair(3, CScript() << sig1 << sig2 << OP_0),
+        std::make_pair(3, CScript() << sig2 << sig1 << OP_0),
+        std::make_pair(3, CScript() << sig1 << sig2),
+        std::make_pair(3, CScript() << sig2 << sig1),
+        std::make_pair(4, CScript() << OP_0 << OP_0 << sig3),
+        std::make_pair(4, CScript() << OP_0 << sig3 << OP_0),
+        std::make_pair(4, CScript() << sig3 << OP_0 << OP_0),
+        std::make_pair(4, CScript() << OP_0 << sig3),
+        std::make_pair(4, CScript() << sig3 << OP_0),
+        std::make_pair(4, CScript() << sig3),
+        std::make_pair(5, CScript() << OP_0 << sig1 << sig3),
+        std::make_pair(5, CScript() << OP_0 << sig3 << sig1),
+        std::make_pair(5, CScript() << sig1 << OP_0 << sig3),
+        std::make_pair(5, CScript() << sig3 << OP_0 << sig1),
+        std::make_pair(5, CScript() << sig1 << sig3 << OP_0),
+        std::make_pair(5, CScript() << sig3 << sig1 << OP_0),
+        std::make_pair(5, CScript() << sig1 << sig3),
+        std::make_pair(5, CScript() << sig3 << sig1),
+        std::make_pair(6, CScript() << OP_0 << sig2 << sig3),
+        std::make_pair(6, CScript() << OP_0 << sig3 << sig2),
+        std::make_pair(6, CScript() << sig2 << OP_0 << sig3),
+        std::make_pair(6, CScript() << sig3 << OP_0 << sig2),
+        std::make_pair(6, CScript() << sig2 << sig3 << OP_0),
+        std::make_pair(6, CScript() << sig3 << sig2 << OP_0),
+        std::make_pair(6, CScript() << sig2 << sig3),
+        std::make_pair(6, CScript() << sig3 << sig2),
+        std::make_pair(7, CScript() << OP_0 << sig1 << sig2 << sig3),
+        std::make_pair(7, CScript() << sig1 << OP_0 << sig2 << sig3),
+        std::make_pair(7, CScript() << sig1 << sig2 << OP_0 << sig3),
+        std::make_pair(7, CScript() << sig1 << sig2 << sig3 << OP_0),
+        std::make_pair(7, CScript() << sig1 << sig2 << sig3),
+        std::make_pair(0, expected[0]),
+        std::make_pair(1, expected[1]),
+        std::make_pair(2, expected[2]),
+        std::make_pair(3, expected[3]),
+        std::make_pair(4, expected[4]),
+        std::make_pair(5, expected[5]),
+        std::make_pair(6, expected[6]),
+        std::make_pair(7, expected[7]),
+    };
+
+    for (std::size_t i = 0; i < ARRAYLEN(partials); ++i) {
+        for (std::size_t j = 0; j < ARRAYLEN(partials); ++j) {
+            combined = CombineSignatures(scriptPubKey, txTo, 0, partials[i].second, partials[j].second);
+            BOOST_CHECK(combined == expected[partials[i].first | partials[j].first]);
+            combined = CombineSignatures(scriptPubKey, txTo, 0, partials[j].second, partials[i].second);
+            BOOST_CHECK(combined == expected[partials[i].first | partials[j].first]);
+        }
+    }
 }
 
 BOOST_AUTO_TEST_CASE(script_standard_push)

--- a/src/test/transaction_tests.cpp
+++ b/src/test/transaction_tests.cpp
@@ -56,6 +56,7 @@ static std::map<string, unsigned int> mapFlagNames = boost::assign::map_list_of
     (string("SIGPUSHONLY"), (unsigned int)SCRIPT_VERIFY_SIGPUSHONLY)
     (string("MINIMALDATA"), (unsigned int)SCRIPT_VERIFY_MINIMALDATA)
     (string("NULLDUMMY"), (unsigned int)SCRIPT_VERIFY_NULLDUMMY)
+    (string("REQUIRE_VALID_SIGS"), (unsigned int)SCRIPT_VERIFY_REQUIRE_VALID_SIGS)
     (string("DISCOURAGE_UPGRADABLE_NOPS"), (unsigned int)SCRIPT_VERIFY_DISCOURAGE_UPGRADABLE_NOPS)
     (string("CLEANSTACK"), (unsigned int)SCRIPT_VERIFY_CLEANSTACK)
     (string("CHECKLOCKTIMEVERIFY"), (unsigned int)SCRIPT_VERIFY_CHECKLOCKTIMEVERIFY)


### PR DESCRIPTION
The SCRIPT_VERIFY_REQUIRE_VALID_SIGS enforces that every signature check passes when the signature field is non-empty (softfork safe, replaces BIP62 rule 7). Fixes #6.

It is still possible for the non-VERIFY forms of CHECKSIG or CHECKMULTISIG to be executed and return false, but you MUST do so by passing in an empty (OP_0) signature. The way this is implemented is different for the two opcodes:

CHECKSIG and CHECKSIGVERIFY will abort script validation with error code SCRIPT_ERR_FAILED_SIGNATURE_CHECK if the signature validation code returns false for any reason other than the passed-in signature being the empty.

CHECKMULTISIG and CHECKMULTISIGVERIFY present a significant challenge to enforcing this requirement in that the original data format did not indicate which public keys were matched with which signatures, other than the ordering. For a k-of-n multisig, there are n-choose-(n-k) possibilities. For example, a 2-of-3 multisig would have three public keys matched with two signatures, resulting in three possible assignments of pubkeys to signatures. In the original implementation this is done by attempting to validate a signature, starting with the first public key and the first signature, and then moving to the next pubkey if validation fails. It is not known in advance to the validator which attempts will fail.

Thankfully, however, a bug in the original implementation causes an extra, unused item to be removed from stack after validation. Since this value is given no previous consensus meaning, we use it as a bitfield to indicate which pubkeys to skip.

Enforcing this requirement is a necessary precursor step to performing batch validation, since in a batch validation regime individual pubkey-signature combinations would not be checked for validity.

Like bitcoin's SCRIPT_VERIFY_NULLDUMMY, this also serves as a malleability fix since the bitmask value is provided by the witness.

**Draft**: I have found a more compact way to store the multisig bit mask. This PR will not be marked ready to merge until that is implemented, but the rest of the logic can be reviewed now. Also, the unit tests do not pass because they have not been updated yet.