### PR TITLE
[Hard-Fork] Implement time-activated "protocol cleanup" flag-day hard-fork, set to activate in April 2021

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -157,6 +157,26 @@ public:
         nMaxTipAge = 24 * 60 * 60;
 
         /**
+         * The protocol cleanup rule change is scheduled for activation on 2
+         * April 2021 at midnight UTC. This is 4PM PDT, 7PM EDT, and 9AM JST.
+         * Since the activation time is median-time-past, it'll actually
+         * trigger about an hour after this wall-clock time.
+         *
+         * This date is chosen to be roughly 2 years after the expected
+         * release date of official binaries. While the Freicoin developer
+         * team doesn't have the resources to provide strong ongoing support
+         * beyond emergency fixes, we nevertheless have an ideal goal of
+         * supporting release binaries for up to 2 years following the first
+         * release from that series. Any release of a new series prior to the
+         * deployment of forward blocks should set this to be at least two
+         * years from the time of release. When forward blocks is deployed,
+         * this parameter should be set to the highest value used in prior
+         * releases, and becomes the earliest time at which the hard-fork
+         * rules can activate.
+         */
+        protocol_cleanup_activation_time = 1617321600;
+
+        /**
          * Build the genesis block. Note that the output of the genesis coinbase cannot
          * be spent as it did not originally exist in the database.
          * 
@@ -240,6 +260,10 @@ public:
         diff_adjust_threshold = 2016;
         alu_activation_height = 2016;
         nMaxTipAge = 0x7fffffff;
+
+        // Nine months prior to main net
+        // 2 July 2020 00:00:00 UTC
+        protocol_cleanup_activation_time = 1593648000;
 
         //! Modify the testnet genesis block so the timestamp is valid for a later start.
         genesis.nTime = 1356123600;

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -69,6 +69,126 @@ public:
     int ActivateBitUpgradeMajority() const { return activate_bit_upgrade_majority; }
     int ToCheckBitUpgradeMajority() const { return to_check_bit_upgrade_majority; }
 
+    /**
+     * Scheduled protocol cleanup rule change
+     *
+     * To achieve desired scaling limits, the forward blocks architecture
+     * will eventually trigger a hard-fork modification of the consensus
+     * rules, for the primary purpose of dropping enforcement of many
+     * aggregate block limits and altering the difficulty adjustment
+     * algorithm.
+     *
+     * This hard-fork will not activate until it is absolutely necessary
+     * for it to do so, at the point when real demand for additional shard
+     * space in aggregate across all forward block shard-chains exceeds
+     * the available space in the compatibility chain. It is anticipated
+     * that this will not occur until many, many years into the future,
+     * when Freicoin/Tradecraft's usage exceeds even the levels of bitcoin
+     * usage ca. 2018. However when it does eventually trigger, any node
+     * enforcing the old rules will be left behind.
+     *
+     * Since the rule changes for forward blocks have not been written yet
+     * and becauses this flag-day code doesn't know how to detect actual
+     * activation, we cannot have older clients enforce the new rules.
+     * What is done instead is that any rule which we anticipate changes
+     * becomes simply unenforced after this activation time, and aggregate
+     * limits are set to the maximum values the software is able to
+     * support. After the flag-day, older clients of at least version 10.4
+     * will continue to receive blocks, but with only SPV security ("trust
+     * the most work") for the new protocol rules. So starting with the
+     * release of v10.4-8, activation of forward blocks new scaling limits
+     * becomes a soft-fork, with the only concern being the forking off of
+     * 0.9 series and earlier nodes upon activation.
+     *
+     * The primary rules which must be altered for forward blocks scaling
+     * are:
+     *
+     *   1. Significant relaxation of the rules regarding per-block
+     *      difficulty adjustment, to allow adjustments of +/- 2x within
+     *      twelve blocks, without regard of a target interval. Forward
+     *      blocks will have a new difficulty adjustment algorithm that
+     *      has yet to be determined, and will include adjusting to a
+     *      variable inter-block time to achieve compatability chain
+     *      scalability.
+     *
+     *   2. Increase of the maximum block size. Uncapping the block size
+     *      is not possible because even if the explicit limit is removed
+     *      there are still implicit network and disk protocol limits that
+     *      would prevent a client from syncing a chain with larger
+     *      blocks. But these network and disk limits could be set much
+     *      higher than the current limits based on a 1 megabyte
+     *      MAX_BLOCK_SIZE.
+     *
+     *   3. Allow larger transactions, up to the new, larger maximum block
+     *      size limit in size. This is less safe than increasing the
+     *      block size since most of the quadratic validation costs are
+     *      only quadratic in transaction size. But there is research to
+     *      be done in choosing what new limits should be used, and in the
+     *      mean time keeping transactions only limited by the (new) block
+     *      size permits flexibility in that future choice.
+     *
+     * That is all that MUST be done, but there are a number of other rule
+     * changes that are related, or are trivial to accomplish at the same
+     * time. These include:
+     *
+     *   4. Removal of MAX_BLOCK_SIGOPS limit. Switching to libsecp256k1
+     *      for validation (which is done upstream in Bitcoin Core 0.12)
+     *      and better signature / script and transaction validation
+     *      caching has made this limit nearly redundant.
+     *
+     *   5. Allow a transaction without transaction outputs. A transaction
+     *      must have inputs to have a unique transactionn ID, but it need
+     *      not have outputs. There are obscure cases when this makes
+     *      sense to do and (thus forward the funds entirely as "fee" to
+     *      the miner, to process in the coinbase in some way).
+     *
+     *   6. Do not restrict the contents of the "coinbase string" in any
+     *      way. It is currently required to be between 2 and 100 bytes in
+     *      size, and must begin with the serialized block height. The
+     *      length restriction is unnecesary as miners have other means of
+     *      padding transactions if they need to, and are generally
+     *      incentivised not to because of miner fees. The serialized
+     *      height requirement is redundant as lock_height is also
+     *      required to be set to the current block height.
+     *
+     *   7. Reduce coinbase maturity to 1 block. Once forward blocks
+     *      has activated, coinbase maturity is an unnecessary delay
+     *      to processing the coinbase payout queue.
+     *
+     *   8. Do not require zero-valued outputs to be spent by transactions
+     *      with lock_height >= the coin's refheight. This restriction
+     *      ensured that refheights were always increasing so that
+     *      demurrage is collected, not reversed. However this argument
+     *      doesn't really make sense for zero-valued outputs. At the same
+     *      time "zero-valued" outputs are increasingly likely to be used
+     *      for confidential or non-freicoin assets using extension
+     *      outputs, for which monotonic lock_heights are just an annoying
+     *      protocol complication.
+     *
+     *   9. Do not reject "old" blocks after activation of the nVersion=2
+     *      and nVersion=3 soft-forks. With the switch to version bits for
+     *      soft-fork activation, this archaic check is shown to be rather
+     *      pointless. Rules are enforced in a block if it is downstream
+     *      of the point of activation, not based on the nVersion value.
+     *      Implicitly this also allows "negative" block.nVersion values.
+     *
+     *   10. Lift restrictions inside the script interpreter on maximum
+     *       script size, maximum data push, maximum number of elements
+     *       on the stack, and maximum number of executed opcodes.
+     *
+     *   11. Remove checks on disabled opcodes, and cause unrecognized
+     *       opcodes to "return true" instead of raising an error.
+     *
+     *   12. Re-enable (and implement) certain disabled opcodes, and
+     *       conspiciously missing opcodes which were never there in the
+     *       first place.
+     *
+     * These consensus rules are eliminated or significantly relaxed at
+     * the same time as the aggregate limits are removed, hence the
+     * general label a "protocol cleanup" fork.
+     **/
+    int64_t ProtocolCleanupActivationTime() const { return protocol_cleanup_activation_time; }
+
     /** Used if GenerateFreicoins is called with a negative number of threads */
     int DefaultMinerThreads() const { return nMinerThreads; }
     const CBlock& GenesisBlock() const { return genesis; }
@@ -117,6 +237,7 @@ protected:
     int nToCheckBlockUpgradeMajority;
     int activate_bit_upgrade_majority;
     int to_check_bit_upgrade_majority;
+    int64_t protocol_cleanup_activation_time;
     int64_t target_spacing;
     int64_t original_interval;
     int64_t filtered_interval;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -868,17 +868,18 @@ unsigned int GetP2SHSigOpCount(const CTransaction& tx, const CCoinsViewCache& in
 
 
 
-bool CheckTransaction(const CTransaction& tx, CValidationState &state)
+bool CheckTransaction(const CTransaction& tx, CValidationState &state, bool protocol_cleanup)
 {
     // Basic checks that don't depend on any context
     if (tx.vin.empty())
         return state.DoS(10, error("CheckTransaction() : vin empty"),
                          REJECT_INVALID, "bad-txns-vin-empty");
-    if (tx.vout.empty())
+    if (!protocol_cleanup && tx.vout.empty())
         return state.DoS(10, error("CheckTransaction() : vout empty"),
                          REJECT_INVALID, "bad-txns-vout-empty");
     // Size limits
-    if (::GetSerializeSize(tx, SER_NETWORK, PROTOCOL_VERSION) > MAX_BLOCK_SIZE)
+    const std::size_t max_block_size = protocol_cleanup ? MAX_BLOCKFILE_SIZE : MAX_BLOCK_SIZE;
+    if (::GetSerializeSize(tx, SER_NETWORK, PROTOCOL_VERSION) > max_block_size)
         return state.DoS(100, error("CheckTransaction() : size limits failed"),
                          REJECT_INVALID, "bad-txns-oversize");
 
@@ -910,7 +911,7 @@ bool CheckTransaction(const CTransaction& tx, CValidationState &state)
 
     if (tx.IsCoinBase())
     {
-        if (tx.vin[0].scriptSig.size() < 2 || tx.vin[0].scriptSig.size() > 100)
+        if (!protocol_cleanup && (tx.vin[0].scriptSig.size() < 2 || tx.vin[0].scriptSig.size() > 100))
             return state.DoS(100, error("CheckTransaction() : coinbase script size"),
                              REJECT_INVALID, "bad-cb-length");
     }
@@ -962,7 +963,10 @@ bool AcceptToMemoryPool(CTxMemPool& pool, CValidationState &state, const CTransa
     if (pfMissingInputs)
         *pfMissingInputs = false;
 
-    if (!CheckTransaction(tx, state))
+    // Check for activation of rule changes
+    const bool protocol_cleanup = IsProtocolCleanupActive(Params(), chainActive.Tip());
+
+    if (!CheckTransaction(tx, state, protocol_cleanup))
         return error("AcceptToMemoryPool: : CheckTransaction failed");
 
     // Coinbase is only valid in a block, not as a loose transaction
@@ -1046,7 +1050,7 @@ bool AcceptToMemoryPool(CTxMemPool& pool, CValidationState &state, const CTransa
         // merely non-standard transaction.
         unsigned int nSigOps = GetLegacySigOpCount(tx);
         nSigOps += GetP2SHSigOpCount(tx, view);
-        if (nSigOps > MAX_TX_SIGOPS)
+        if (!protocol_cleanup && (nSigOps > MAX_TX_SIGOPS))
             return state.DoS(0,
                              error("AcceptToMemoryPool : too many sigops %s, %d > %d",
                                    hash.ToString(), nSigOps, MAX_TX_SIGOPS),
@@ -1102,7 +1106,9 @@ bool AcceptToMemoryPool(CTxMemPool& pool, CValidationState &state, const CTransa
 
         // Check against previous transactions
         // This is done last to help prevent CPU exhaustion denial-of-service attacks.
-        if (!CheckInputs(tx, state, view, 0, true, STANDARD_SCRIPT_VERIFY_FLAGS, true))
+        unsigned int flags = STANDARD_SCRIPT_VERIFY_FLAGS
+                           | (protocol_cleanup? SCRIPT_VERIFY_PROTOCOL_CLEANUP: 0);
+        if (!CheckInputs(tx, state, view, 0, true, flags, true))
         {
             return error("AcceptToMemoryPool: : ConnectInputs failed %s", hash.ToString());
         }
@@ -1116,7 +1122,9 @@ bool AcceptToMemoryPool(CTxMemPool& pool, CValidationState &state, const CTransa
         // There is a similar check in CreateNewBlock() to prevent creating
         // invalid blocks, however allowing such transactions into the mempool
         // can be exploited as a DoS attack.
-        if (!CheckInputs(tx, state, view, 0, true, MANDATORY_SCRIPT_VERIFY_FLAGS, true))
+        flags = MANDATORY_SCRIPT_VERIFY_FLAGS
+              | (protocol_cleanup? SCRIPT_VERIFY_PROTOCOL_CLEANUP: 0);
+        if (!CheckInputs(tx, state, view, 0, true, flags, true))
         {
             return error("AcceptToMemoryPool: : BUG! PLEASE REPORT THIS! ConnectInputs failed against MANDATORY but not STANDARD flags %s", hash.ToString());
         }
@@ -1448,6 +1456,9 @@ bool CScriptCheck::operator()() {
 
 bool CheckInputs(const CTransaction& tx, CValidationState &state, const CCoinsViewCache &inputs, int per_input_adjustment, bool fScriptChecks, unsigned int flags, bool cacheStore, std::vector<CScriptCheck> *pvChecks)
 {
+    // Check for activation of rule changes
+    const bool protocol_cleanup = (flags & SCRIPT_VERIFY_PROTOCOL_CLEANUP) != 0;
+
     if (!tx.IsCoinBase())
     {
         if (pvChecks)
@@ -1472,14 +1483,16 @@ bool CheckInputs(const CTransaction& tx, CValidationState &state, const CCoinsVi
 
             // If prev is coinbase, check that it's matured
             if (coins->IsCoinBase()) {
-                if (nSpendHeight - coins->nHeight < COINBASE_MATURITY)
+                if (nSpendHeight - coins->nHeight < (protocol_cleanup ? 1 : COINBASE_MATURITY))
                     return state.Invalid(
                         error("CheckInputs() : tried to spend coinbase at depth %d", nSpendHeight - coins->nHeight),
                         REJECT_INVALID, "bad-txns-premature-spend-of-coinbase");
             }
 
             // Check that lock_height is monotonically increasing.
-            if (tx.lock_height < coins->refheight)
+            // This restriction is removed for zero-valued inputs in
+            // the protocol cleanup.
+            if ((coins->vout[prevout.n].nValue || !protocol_cleanup) && (tx.lock_height < coins->refheight))
                 return state.DoS(100, error("CheckInputs() : input refheight less than tx lock_height"),
                                  REJECT_INVALID, "bad-txns-non-monotonic-lock-height");
 
@@ -1702,6 +1715,9 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
 
     bool fScriptChecks = pindex->nHeight >= Checkpoints::GetTotalBlocksEstimate();
 
+    // Check for activation of rule changes
+    const bool protocol_cleanup = IsProtocolCleanupActive(Params(), pindex->pprev);
+
     // Do not allow blocks that contain transactions which 'overwrite' older transactions,
     // unless those are already completely spent.
     // If such overwrites are allowed, coinbases and transactions depending upon those
@@ -1735,9 +1751,12 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
     bool truncate_inputs = false;
 
     unsigned int flags = fStrictPayToScriptHash ? SCRIPT_VERIFY_P2SH : SCRIPT_VERIFY_NONE;
+    if (protocol_cleanup) {
+        flags |= SCRIPT_VERIFY_PROTOCOL_CLEANUP;
+    }
 
     // Start enforcing the DERSIG (BIP66) rules, for block.nVersion=3 blocks, when 75% of the network has upgraded:
-    if (block.nVersion >= 3 && CBlockIndex::IsSuperMajority(3, pindex->pprev, Params().EnforceBlockUpgradeMajority())) {
+    if (protocol_cleanup || (block.nVersion >= 3 && CBlockIndex::IsSuperMajority(3, pindex->pprev, Params().EnforceBlockUpgradeMajority()))) {
         flags |= SCRIPT_VERIFY_DERSIG;
         truncate_inputs = true;
     }
@@ -1791,7 +1810,7 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
 
         nInputs += tx.vin.size();
         nSigOps += GetLegacySigOpCount(tx);
-        if (nSigOps > MAX_BLOCK_SIGOPS)
+        if (!protocol_cleanup && (nSigOps > MAX_BLOCK_SIGOPS))
             return state.DoS(100, error("ConnectBlock() : too many sigops"),
                              REJECT_INVALID, "bad-blk-sigops");
 
@@ -1801,7 +1820,7 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
                 return state.DoS(100, error("ConnectBlock() : inputs missing/spent"),
                                  REJECT_INVALID, "bad-txns-inputs-missingorspent");
 
-            if (fStrictPayToScriptHash)
+            if (!protocol_cleanup && fStrictPayToScriptHash)
             {
                 // Add in sigops done by pay-to-script-hash inputs;
                 // this is to prevent a "rogue miner" from creating
@@ -2529,12 +2548,16 @@ bool CheckBlock(const CBlock& block, CValidationState& state, bool fCheckPOW, bo
                              REJECT_INVALID, "bad-txns-duplicate", true);
     }
 
+    // Check if the protocol-cleanup fork has activated
+    const bool protocol_cleanup = IsProtocolCleanupActive(Params(), block);
+
     // All potential-corruption validation must be done before we do any
     // transaction validation, as otherwise we may mark the header as invalid
     // because we receive the wrong transactions for it.
 
     // Size limits
-    if (block.vtx.empty() || block.vtx.size() > MAX_BLOCK_SIZE || ::GetSerializeSize(block, SER_NETWORK, PROTOCOL_VERSION) > MAX_BLOCK_SIZE)
+    const std::size_t max_block_size = protocol_cleanup ? (MAX_BLOCKFILE_SIZE-8) : MAX_BLOCK_SIZE;
+    if (block.vtx.empty() || block.vtx.size() > max_block_size || ::GetSerializeSize(block, SER_NETWORK, PROTOCOL_VERSION) > max_block_size)
         return state.DoS(100, error("CheckBlock() : size limits failed"),
                          REJECT_INVALID, "bad-blk-length");
 
@@ -2549,7 +2572,7 @@ bool CheckBlock(const CBlock& block, CValidationState& state, bool fCheckPOW, bo
 
     // Check transactions
     BOOST_FOREACH(const CTransaction& tx, block.vtx)
-        if (!CheckTransaction(tx, state))
+        if (!CheckTransaction(tx, state, protocol_cleanup))
             return error("CheckBlock() : CheckTransaction failed");
 
     unsigned int nSigOps = 0;
@@ -2557,7 +2580,7 @@ bool CheckBlock(const CBlock& block, CValidationState& state, bool fCheckPOW, bo
     {
         nSigOps += GetLegacySigOpCount(tx);
     }
-    if (nSigOps > MAX_BLOCK_SIGOPS)
+    if (!protocol_cleanup && (nSigOps > MAX_BLOCK_SIGOPS))
         return state.DoS(100, error("CheckBlock() : out-of-bounds SigOpCount"),
                          REJECT_INVALID, "bad-blk-sigops", true);
 
@@ -2574,9 +2597,11 @@ bool ContextualCheckBlockHeader(const CBlockHeader& block, CValidationState& sta
 
     int nHeight = pindexPrev->nHeight+1;
 
+    // Check for activation of rule changes
+    const bool protocol_cleanup = IsProtocolCleanupActive(Params(), pindexPrev);
+
     // Check proof of work
-    if ((!Params().SkipProofOfWorkCheck()) &&
-       (block.nBits != GetNextWorkRequired(pindexPrev, &block)))
+    if (!Params().SkipProofOfWorkCheck() && (protocol_cleanup ? CheckNextWorkRequired(pindexPrev, block) : (block.nBits != GetNextWorkRequired(pindexPrev, &block))))
         return state.DoS(100, error("%s : incorrect proof of work", __func__),
                          REJECT_INVALID, "bad-diffbits");
 
@@ -2596,15 +2621,14 @@ bool ContextualCheckBlockHeader(const CBlockHeader& block, CValidationState& sta
         return state.DoS(100, error("%s : forked chain older than last checkpoint (height %d)", __func__, nHeight));
 
     // Reject block.nVersion=1 blocks when 95% (75% on testnet) of the network has upgraded:
-    if (block.nVersion < 2 && 
-        CBlockIndex::IsSuperMajority(2, pindexPrev, Params().RejectBlockOutdatedMajority()))
+    if (!protocol_cleanup && (block.nVersion < 2) && CBlockIndex::IsSuperMajority(2, pindexPrev, Params().RejectBlockOutdatedMajority()))
     {
         return state.Invalid(error("%s : rejected nVersion=1 block", __func__),
                              REJECT_OBSOLETE, "bad-version");
     }
 
     // Reject block.nVersion=2 blocks when 95% (75% on testnet) of the network has upgraded:
-    if (block.nVersion < 3 && CBlockIndex::IsSuperMajority(3, pindexPrev, Params().RejectBlockOutdatedMajority()))
+    if (!protocol_cleanup && block.nVersion < 3 && CBlockIndex::IsSuperMajority(3, pindexPrev, Params().RejectBlockOutdatedMajority()))
     {
         return state.Invalid(error("%s : rejected nVersion=2 block", __func__),
                              REJECT_OBSOLETE, "bad-version");
@@ -2623,6 +2647,9 @@ bool ContextualCheckBlock(const CBlock& block, CValidationState& state, CBlockIn
 {
     const int nHeight = pindexPrev == NULL ? 0 : pindexPrev->nHeight + 1;
 
+    // Check for activation of rule changes
+    const bool protocol_cleanup = IsProtocolCleanupActive(Params(), pindexPrev);
+
     // Check that all transactions are finalized
     BOOST_FOREACH(const CTransaction& tx, block.vtx)
         if (!IsFinalTx(tx, nHeight, block.GetBlockTime())) {
@@ -2631,8 +2658,7 @@ bool ContextualCheckBlock(const CBlock& block, CValidationState& state, CBlockIn
 
     // Enforce block.nVersion=2 rule that the coinbase starts with serialized block height
     // if 750 of the last 1,000 blocks are version 2 or greater (51/100 if testnet):
-    if (block.nVersion >= 2 && 
-        CBlockIndex::IsSuperMajority(2, pindexPrev, Params().EnforceBlockUpgradeMajority()))
+    if (!protocol_cleanup && (block.nVersion >= 2) && CBlockIndex::IsSuperMajority(2, pindexPrev, Params().EnforceBlockUpgradeMajority()))
     {
         CScript expect = CScript() << nHeight;
         if (block.vtx[0].vin[0].scriptSig.size() < expect.size() ||

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -42,6 +42,8 @@
 #include <miniupnpc/upnperrors.h>
 #endif
 
+#include <algorithm>
+
 #include <boost/filesystem.hpp>
 #include <boost/thread.hpp>
 
@@ -594,7 +596,44 @@ bool CNode::ReceiveMsgBytes(const char *pch, unsigned int nBytes)
         if (handled < 0)
                 return false;
 
-        if (msg.in_data && msg.hdr.nMessageSize > MAX_PROTOCOL_MESSAGE_LENGTH) {
+        // Unconstraining the block size in the protocol cleanup fork
+        // means that network message size must also be unconstrained,
+        // which is a potential DoS vector. Unfortunately there is no
+        // easy way around this. Until better tools are available in
+        // future versions, we must accept that after activation of
+        // the protocol cleanup fork we might receive a message up to
+        // the largest possible block size, which is limited only by
+        // MAX_BLOCKFILE_SIZE.
+        //
+        // However this value is dangerously high for 32-bit clients,
+        // as it presents an easy DoS vector for memory exhaustion
+        // attacks. We therefore use a lower limit for 32-bit builds
+        // which prevents exhaustion of the memory address space with
+        // the maximum number of connected peers. This does mean that
+        // 32-bit clients will stop being able to synchronize from the
+        // network once blocks genuinely grow larger than 16MiB. But
+        // as it is doubtful that a true 32-bit peer could keep up
+        // with the network in such an instance, this is deemed an
+        // acceptable tradeoff.
+        size_t max_msg_size = MAX_PROTOCOL_MESSAGE_LENGTH;
+        if (GetAdjustedTime() > (Params().ProtocolCleanupActivationTime() - 2*60*60 /* two hours */)) {
+            // Use no more than 2GiB for messages in flight on 32-bit
+            // peers. With the default max of 125 connections this is
+            // slightly more than 16MiB. A 32-bit node operator could
+            // indirectly raise this value by lowering the maximum
+            // number of allowed connections in their configuration
+            // file. But we will not decrease below this amount just
+            // because user configured their node to accept more
+            // inbound peers than the default.
+            size_t max_data_per_peer = numeric_limits<size_t>::max() / std::max(nMaxConnections, 125) / 2;
+            // On 64-bit nodes, the above calculation results in an
+            // enormous number, so we use the lower implicit protocol
+            // rule of the maximum blockfile size--a block larger than
+            // this value could not be stored to disk.
+            max_msg_size = std::min(max_data_per_peer, static_cast<size_t>(MAX_BLOCKFILE_SIZE));
+        }
+
+        if (msg.in_data && msg.hdr.nMessageSize > max_msg_size) {
             LogPrint("net", "Oversized message from peer=%i, disconnecting\n", GetId());
             return false;
         }

--- a/src/pow.cpp
+++ b/src/pow.cpp
@@ -197,6 +197,54 @@ unsigned int GetNextWorkRequired(const CBlockIndex* pindexLast, const CBlockHead
     return bnNew.GetCompact();
 }
 
+// Called after activation of the protocol-cleanup rule changes, at
+// which time the difficulty adjustment is largely unchecked. For DoS
+// prevention purposes we require that the difficulty adjust by no
+// more than +/- 2x as compared with the difficulties of the last 12
+// blocks. This is enough of a constraint that any DoS attack is
+// forced to have non-trivial mining costs (e.g. equal to extending
+// the tip by 6 blocks to reduce difficulty by more than a half, work
+// equal to extending the tip by 9 blocks to reduce by more than a
+// quarter, 10.5 times present difficulty to reduce by more than an
+// eigth, etc. To reduce to arbitrary levels requires 12 blocks worth
+// of work at the difficulty of the last valid block.
+bool CheckNextWorkRequired(const CBlockIndex* pindexLast, const CBlockHeader& block)
+{
+    // Special case for the genesis block
+    if (!pindexLast) {
+        return (block.nBits == Params().GenesisBlock().nBits);
+    }
+
+    // If look reversed, that is to be expected. We set min to the
+    // largest possible value, and max to the smallest. That way these
+    // will be replaced with actual block values as we loop through
+    // the past 12 blocks.
+    uint256 min = Params().ProofOfWorkLimit().GetCompact();
+    uint256 max = uint256(1);
+
+    // After this loop, min will be half the largest work target of
+    // the past 12 blocks, and max will be twice the smallest.
+    for (int i = 0; i < 12 && pindexLast; ++i, pindexLast = pindexLast->pprev) {
+        uint256 target;
+        target.SetCompact(pindexLast->nBits);
+        uint256 local_min = target >> 1;
+        uint256 local_max = target << 1;
+        if (min > local_min) {
+            min = local_min;
+        }
+        if (max < local_max) {
+            max = local_max;
+        }
+    }
+
+    // See if the passed in block's nBits specifies a target within
+    // the range of half to twice the work targets of the past 12
+    // blocks, inclusive of the endpoints.
+    uint256 target;
+    target.SetCompact(block.nBits);
+    return ((min <= target) && (target <= max));
+}
+
 bool CheckProofOfWork(uint256 hash, unsigned int nBits)
 {
     bool fNegative;

--- a/src/pow.h
+++ b/src/pow.h
@@ -30,6 +30,10 @@ int64_t GetFilteredTime(const CBlockIndex* pindexLast);
 
 unsigned int GetNextWorkRequired(const CBlockIndex* pindexLast, const CBlockHeader *pblock);
 
+/** Verify that a block's work target is within the range of half to
+ ** twice the targets of the past 12 blocks. */
+bool CheckNextWorkRequired(const CBlockIndex* pindexLast, const CBlockHeader& block);
+
 /** Check whether a block hash satisfies the proof-of-work requirement specified by nBits */
 bool CheckProofOfWork(uint256 hash, unsigned int nBits);
 uint256 GetBlockProof(const CBlockIndex& block);

--- a/src/primitives/block.h
+++ b/src/primitives/block.h
@@ -26,6 +26,8 @@
 
 /** The maximum allowed size for a serialized block, in bytes (network rule) */
 static const unsigned int MAX_BLOCK_SIZE = 1000000;
+/** The maximum size of a blk?????.dat file (since 0.8) (implicit network rule) */
+static const unsigned int MAX_BLOCKFILE_SIZE = 0x7f000000; // (2048 - 16) MiB
 
 /** Nodes collect new transactions into a block, hash them into a hash tree,
  * and scan through nonce values to make the block's hash satisfy proof-of-work

--- a/src/script/interpreter.cpp
+++ b/src/script/interpreter.cpp
@@ -259,6 +259,10 @@ bool EvalScript(vector<vector<unsigned char> >& stack, const CScript& script, un
     static const valtype vchZero(0);
     static const valtype vchTrue(1, 1);
 
+    // Check for activation of rule changes
+    const bool protocol_cleanup = (flags & SCRIPT_VERIFY_PROTOCOL_CLEANUP) != 0;
+    const bool discourage_upgradable_nops = (flags & SCRIPT_VERIFY_DISCOURAGE_UPGRADABLE_NOPS) != 0;
+
     CScript::const_iterator pc = script.begin();
     CScript::const_iterator pend = script.end();
     CScript::const_iterator pbegincodehash = script.begin();
@@ -267,7 +271,7 @@ bool EvalScript(vector<vector<unsigned char> >& stack, const CScript& script, un
     vector<bool> vfExec;
     vector<valtype> altstack;
     set_error(serror, SCRIPT_ERR_UNKNOWN_ERROR);
-    if (script.size() > 10000)
+    if (!protocol_cleanup && (script.size() > 10000))
         return set_error(serror, SCRIPT_ERR_SCRIPT_SIZE);
     int nOpCount = 0;
     bool fRequireMinimal = (flags & SCRIPT_VERIFY_MINIMALDATA) != 0;
@@ -281,16 +285,23 @@ bool EvalScript(vector<vector<unsigned char> >& stack, const CScript& script, un
             //
             // Read instruction
             //
+            // Note: GetOp only fails if the instruction was a
+            // malformed push, or if (due to some bug) the code
+            // pointer points beyond the end of the script. We
+            // therefore don't relax this "bad opcode" restriction in
+            // the protocol cleanup. Valid decoded but unrecognized
+            // instructions will be handled later.
             if (!script.GetOp(pc, opcode, vchPushValue))
                 return set_error(serror, SCRIPT_ERR_BAD_OPCODE);
-            if (vchPushValue.size() > MAX_SCRIPT_ELEMENT_SIZE)
+            if (!protocol_cleanup && (vchPushValue.size() > MAX_SCRIPT_ELEMENT_SIZE))
                 return set_error(serror, SCRIPT_ERR_PUSH_SIZE);
 
             // Note how OP_RESERVED does not count towards the opcode limit.
-            if (opcode > OP_16 && ++nOpCount > 201)
+            if (!protocol_cleanup && (opcode > OP_16) && (++nOpCount > 201))
                 return set_error(serror, SCRIPT_ERR_OP_COUNT);
 
-            if (opcode == OP_CAT ||
+            if (!protocol_cleanup && (
+                opcode == OP_CAT ||
                 opcode == OP_SUBSTR ||
                 opcode == OP_LEFT ||
                 opcode == OP_RIGHT ||
@@ -304,7 +315,7 @@ bool EvalScript(vector<vector<unsigned char> >& stack, const CScript& script, un
                 opcode == OP_DIV ||
                 opcode == OP_MOD ||
                 opcode == OP_LSHIFT ||
-                opcode == OP_RSHIFT)
+                opcode == OP_RSHIFT))
                 return set_error(serror, SCRIPT_ERR_DISABLED_OPCODE); // Disabled opcodes.
 
             if (fExec && 0 <= opcode && opcode <= OP_PUSHDATA4) {
@@ -888,7 +899,7 @@ bool EvalScript(vector<vector<unsigned char> >& stack, const CScript& script, un
                     if (nKeysCount < 0 || nKeysCount > 20)
                         return set_error(serror, SCRIPT_ERR_PUBKEY_COUNT);
                     nOpCount += nKeysCount;
-                    if (nOpCount > 201)
+                    if (!protocol_cleanup && (nOpCount > 201))
                         return set_error(serror, SCRIPT_ERR_OP_COUNT);
                     int ikey = ++i;
                     i += nKeysCount;
@@ -973,11 +984,17 @@ bool EvalScript(vector<vector<unsigned char> >& stack, const CScript& script, un
                 break;
 
                 default:
-                    return set_error(serror, SCRIPT_ERR_BAD_OPCODE);
+                    if (!protocol_cleanup) {
+                        return set_error(serror, SCRIPT_ERR_BAD_OPCODE);
+                    }
+                    if (discourage_upgradable_nops) {
+                        return set_error(serror, SCRIPT_ERR_DISCOURAGE_UPGRADABLE_NOPS);
+                    }
+                    return set_success(serror);
             }
 
             // Size limits
-            if (stack.size() + altstack.size() > 1000)
+            if (!protocol_cleanup && (stack.size() + altstack.size() > 1000))
                 return set_error(serror, SCRIPT_ERR_STACK_SIZE);
         }
     }

--- a/src/script/interpreter.h
+++ b/src/script/interpreter.h
@@ -89,12 +89,29 @@ enum
     // discouraged NOPs fails the script. This verification flag will never be
     // a mandatory flag applied to scripts in a block. NOPs that are not
     // executed, e.g.  within an unexecuted IF ENDIF block, are *not* rejected.
+    //
+    // Also discourage use of undefined opcodes after protocol cleanup fork activation
+    //
+    // If the protocol-cleanup fork is activated, undefined opcodes
+    // have "return true" semantics, meaning that encountering such an
+    // opcode results in the immediate SUCCESSFUL(!) termination of
+    // script execution. Before activation they will be given less
+    // dangerous semantics, but until then they are treated as
+    // discouraged as well, even though they aren't 'NOP' opcodes as
+    // the name implies.
     SCRIPT_VERIFY_DISCOURAGE_UPGRADABLE_NOPS  = (1U << 7),
 
     // Verify CHECKLOCKTIMEVERIFY
     //
     // See BIP65 for details.
     SCRIPT_VERIFY_CHECKLOCKTIMEVERIFY = (1U << 9),
+
+    // Set if we are relaxing some of the overly restrictive protocol rules as
+    // part of the "protocol cleanup" hard-fork. See chainparams.h for
+    // further description. This flag is a bit unlike the other script
+    // verification flags, but it is the easiest way to pass this
+    // parameter around the script validation code.
+    SCRIPT_VERIFY_PROTOCOL_CLEANUP = (1U << 29),
 
     // If set, do not serialize CTransaction::lock_height in SignatureHash
     //

--- a/src/serialize.h
+++ b/src/serialize.h
@@ -34,7 +34,17 @@
 
 class CScript;
 
-static const unsigned int MAX_SIZE = 0x02000000;
+/**
+ * This is set to MAX_BLOCKFILE_SIZE, plus 1.25kB. The largest
+ * possible thing that is currently serialized is a relay message for
+ * a full block after activation of the protocol-cleanup rule changes,
+ * which is limited to MAX_BLOCKFILE_SIZE - 8 + 24 bytes. But it is
+ * rather costless to add more than a full kilobyte of extra space
+ * just to be sure that we aren't accidentally adding a network
+ * synchronization consensus rule now or as a result of future chages.
+ * "1.25kB should be enough block metadata for anybody."
+ */
+static const unsigned int MAX_SIZE = 0x7f000500; /* MAX_BLOCKFILE_SIZE + 1.25kB */
 
 /**
  * Used to bypass the rule against non-const reference to temporary

--- a/src/test/sighash_tests.cpp
+++ b/src/test/sighash_tests.cpp
@@ -212,7 +212,7 @@ BOOST_AUTO_TEST_CASE(sighash_from_data)
           stream >> tx;
 
           CValidationState state;
-          BOOST_CHECK_MESSAGE(CheckTransaction(tx, state), strTest);
+          BOOST_CHECK_MESSAGE(CheckTransaction(tx, state, false), strTest);
           BOOST_CHECK(state.IsValid());
 
           std::vector<unsigned char> raw = ParseHex(raw_script);

--- a/src/test/transaction_tests.cpp
+++ b/src/test/transaction_tests.cpp
@@ -148,7 +148,7 @@ BOOST_AUTO_TEST_CASE(tx_valid)
             stream >> tx;
 
             CValidationState state;
-            BOOST_CHECK_MESSAGE(CheckTransaction(tx, state), strTest);
+            BOOST_CHECK_MESSAGE(CheckTransaction(tx, state, false), strTest);
             BOOST_CHECK(state.IsValid());
 
             for (unsigned int i = 0; i < tx.vin.size(); i++)
@@ -225,7 +225,7 @@ BOOST_AUTO_TEST_CASE(tx_invalid)
             stream >> tx;
 
             CValidationState state;
-            fValid = CheckTransaction(tx, state) && state.IsValid();
+            fValid = CheckTransaction(tx, state, false) && state.IsValid();
 
             for (unsigned int i = 0; i < tx.vin.size() && fValid; i++)
             {
@@ -254,11 +254,11 @@ BOOST_AUTO_TEST_CASE(basic_transaction_tests)
     CMutableTransaction tx;
     stream >> tx;
     CValidationState state;
-    BOOST_CHECK_MESSAGE(CheckTransaction(tx, state) && state.IsValid(), "Simple deserialized transaction should be valid.");
+    BOOST_CHECK_MESSAGE(CheckTransaction(tx, state, false) && state.IsValid(), "Simple deserialized transaction should be valid.");
 
     // Check that duplicate txins fail
     tx.vin.push_back(tx.vin[0]);
-    BOOST_CHECK_MESSAGE(!CheckTransaction(tx, state) || !state.IsValid(), "Transaction with duplicate txins should be invalid.");
+    BOOST_CHECK_MESSAGE(!CheckTransaction(tx, state, false) || !state.IsValid(), "Transaction with duplicate txins should be invalid.");
 }
 
 //

--- a/src/walletdb.cpp
+++ b/src/walletdb.cpp
@@ -384,7 +384,7 @@ ReadKeyValue(CWallet* pwallet, CDataStream& ssKey, CDataStream& ssValue,
             CWalletTx wtx;
             ssValue >> wtx;
             CValidationState state;
-            if (!(CheckTransaction(wtx, state) && (wtx.GetHash() == hash) && state.IsValid()))
+            if (!(CheckTransaction(wtx, state, wtx.GetTxTime() >= Params().ProtocolCleanupActivationTime()) && (wtx.GetHash() == hash) && state.IsValid()))
                 return false;
 
             // Undo serialize changes in 31600


### PR DESCRIPTION
To achieve desired scaling limits, the forward blocks architecture will eventually trigger a hard-fork modification of the consensus rules, for the primary purposes of dropping enforcement of many aggregate block limits and altering the difficulty adjustment algorithm.

This hard-fork will not activate until it is absolutely necessary for it to do so, at the point when real demand for additional shard space in aggregate across all forward block shard-chains exceeds the available space in the compatibility chain. It is anticipated that this will not occur until many, many years into the future, when Freicoin/Tradecraft's usage exceeds even the levels of bitcoin usage ca. 2018. However when it does eventually trigger, any node enforcing the old rules will be left behind.

Since the rule changes for forward blocks have not been written yet and because this flag-day code doesn't know how to detect actual activation, we cannot have older clients enforce the new rules. What is do instead is that any rule which we anticipate changes becomes simply unenforced after this activation time, and aggregate limits are set to the maximum values the software is able to support. After the flag-day, older clients of at least version 10.4 will continue to receive blocks, but with only SPV security ("trust the most work") for the new protocol rules. So starting with the release of 10.4, activation of forward blocks new scaling limits becomes a soft-fork, with the only concern being the forking off of pre-10.4 nodes upon activation.

The protocol cleanup rule change is scheduled for activation on 2 April 2021 at midnight UTC. This is 4PM PDT, 7PM EDT, and 9AM JST. Since the activation time is median-time-past, it'll actually trigger about an hour after this wall-clock time.

This date is chosen to be roughly 2 years after the expected release date of official binaries. While the Freicoin developer team doesn't have the resources to provide strong ongoing support beyond emergency fixes, we nevertheless have an ideal goal of supporting release binaries for up to 2 years following the first release from that series. Any release of a new series prior to the deployment of forward blocks should set this to be at least two years from the time of release. When forward blocks is deployed, this parameter should be set to the highest value used in prior releases, and becomes the earliest time at which the hard-fork rules can activate.

Fixess #19 .