### PR TITLE
[Standard] Remove SCRIPT_VERIFY_NULLDUMMY from the standard verification flags

### DIFF
--- a/src/script/standard.h
+++ b/src/script/standard.h
@@ -62,7 +62,6 @@ static const unsigned int STANDARD_SCRIPT_VERIFY_FLAGS = MANDATORY_SCRIPT_VERIFY
                                                          SCRIPT_VERIFY_DERSIG |
                                                          SCRIPT_VERIFY_STRICTENC |
                                                          SCRIPT_VERIFY_MINIMALDATA |
-                                                         SCRIPT_VERIFY_NULLDUMMY |
                                                          SCRIPT_VERIFY_DISCOURAGE_UPGRADABLE_NOPS;
 
 /** For convenience, standard but not mandatory verify flags. */


### PR DESCRIPTION
`NULLDUMMY` will be replaced with `REQUIRE_VALID_SIGNATURES` in a future releases.  In order to prevent treating transactions created in this way as non-standard, we remove the `NULLDUMMY` flag from the `STANDARD_SCRIPT_VERIFY_FLAGS` rules.

This is no change from the current situation in release v0.9.5.1-5869. It simply pushes back enforcement of any relay rules regarding the `CHECKMULTISIG` dummy value.