### PR TITLE
[Soft-fork] Require the nTimeLock value of a coinbase transaction to be equal to the median of the past 11 block times

### DIFF
--- a/src/chain.h
+++ b/src/chain.h
@@ -257,6 +257,12 @@ public:
      */
     static bool IsSuperMajority(int minVersion, const CBlockIndex* pstart,
                                 unsigned int nRequired);
+    /**
+     * Returns true if there are nRequried or more version-bits blocks
+     * signaling the bit indicated in the last nToCheck blocks,
+     * starting at pstart and going backwards.
+     */
+    static bool IsSuperMajorityBit(int bit, const CBlockIndex* pstart);
 
     std::string ToString() const
     {

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -146,6 +146,8 @@ public:
         nEnforceBlockUpgradeMajority = 750;
         nRejectBlockOutdatedMajority = 950;
         nToCheckBlockUpgradeMajority = 1000;
+        activate_bit_upgrade_majority = 958;
+        to_check_bit_upgrade_majority = 1008;
         nMinerThreads = 0;
         target_spacing = 10 * 60;
         original_interval = 2016; //! two weeks
@@ -178,6 +180,10 @@ public:
         hashGenesisBlock = genesis.GetHash();
         assert(hashGenesisBlock == uint256("0x000000005b1e3d23ecfd2dd4a6e1a35238aa0392c0a8528c40df52376d7efe2c"));
         assert(genesis.hashMerkleRoot == uint256("0xf53b1baa971ea40be88cf51288aabd700dfec96c486bf7155a53a4919af4c8bd"));
+
+        // Wednesday, October 2, 2019 00:00:00 UTC
+        // This is 4PM PDT, 7PM EDT, and 9AM JST.
+        verify_coinbase_timelock_activation_time = 1569974400;
 
         vSeeds.push_back(CDNSSeedData("node.freico.in", "seed.freico.in"));
         vSeeds.push_back(CDNSSeedData("abacus.freico.in", "fledge.freico.in"));
@@ -225,6 +231,8 @@ public:
         nEnforceBlockUpgradeMajority = 51;
         nRejectBlockOutdatedMajority = 75;
         nToCheckBlockUpgradeMajority = 100;
+        activate_bit_upgrade_majority = 108;
+        to_check_bit_upgrade_majority = 144;
         nMinerThreads = 0;
         target_spacing = 10 * 60;
         original_interval = 2016; //! two weeks
@@ -238,6 +246,9 @@ public:
         genesis.nNonce = 3098244593UL;
         hashGenesisBlock = genesis.GetHash();
         assert(hashGenesisBlock == uint256("0x00000000a52504ffe3420a43bd385ef24f81838921a903460b235d95f37cd65e"));
+
+        // Tuesday, April 2, 2019 00:00:00 UTC
+        verify_coinbase_timelock_activation_time = 1554163200;
 
         vFixedSeeds.clear();
         vSeeds.clear();

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -65,6 +65,9 @@ public:
     int EnforceBlockUpgradeMajority() const { return nEnforceBlockUpgradeMajority; }
     int RejectBlockOutdatedMajority() const { return nRejectBlockOutdatedMajority; }
     int ToCheckBlockUpgradeMajority() const { return nToCheckBlockUpgradeMajority; }
+    /** Used to check majorities for hybrid version bits upgrade */
+    int ActivateBitUpgradeMajority() const { return activate_bit_upgrade_majority; }
+    int ToCheckBitUpgradeMajority() const { return to_check_bit_upgrade_majority; }
 
     /** Used if GenerateFreicoins is called with a negative number of threads */
     int DefaultMinerThreads() const { return nMinerThreads; }
@@ -87,6 +90,7 @@ public:
     int64_t FilteredTargetTimespan() const { return filtered_interval * target_spacing; }
     int64_t DiffAdjustThreshold() const { return diff_adjust_threshold; }
     int64_t AluActivationHeight() const { return alu_activation_height; }
+    int64_t VerifyCoinbaseTimelockActivationTime() const { return verify_coinbase_timelock_activation_time; }
     int64_t MaxTipAge() const { return nMaxTipAge; }
     /** Make miner stop after a block is found. In RPC, don't return until nGenProcLimit blocks are generated */
     bool MineBlocksOnDemand() const { return fMineBlocksOnDemand; }
@@ -111,11 +115,14 @@ protected:
     int nEnforceBlockUpgradeMajority;
     int nRejectBlockOutdatedMajority;
     int nToCheckBlockUpgradeMajority;
+    int activate_bit_upgrade_majority;
+    int to_check_bit_upgrade_majority;
     int64_t target_spacing;
     int64_t original_interval;
     int64_t filtered_interval;
     int64_t diff_adjust_threshold;
     int64_t alu_activation_height;
+    int64_t verify_coinbase_timelock_activation_time;
     int nMinerThreads;
     long nMaxTipAge;
     std::vector<CDNSSeedData> vSeeds;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1748,6 +1748,31 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
         use_alu = true;
     }
 
+    // Verify that the lock-time of the coinbase is equal to the
+    // current median-time-past value, if that rule is active.
+    //
+    // The following code enforces the verify-coinbase-locktime rule
+    // if the median time past exceeds some default flag date, OR if
+    // 95% of the last 1,008(=1 week) blocks (75% of the last 144[=1
+    // day] blocks on testnet) signal support. A separate rule in
+    // AcceptBlock() rejects non-signaling blocks once activation has
+    // triggered, until the timeout date.
+    //
+    // This is a hybrid of the old-style super-majority rollout
+    // mechanism with BIP8/BIP9-like version bits and BIP8-like
+    // activation-on-timeout semantics. It's not strictly compatible
+    // with those BIPs though, as we didn't want to back port all the
+    // necessary state management code. But miners using BIP8/BIP9
+    // compatible version bit software should work with this rollout
+    // by configuring their devices to signal bit #28 (the
+    // highest-order BIP8/BIP9 bit).
+    if ((pindex->pprev->GetMedianTimePast() >= Params().VerifyCoinbaseTimelockActivationTime()) || (((block.nVersion >> 28) == 3) && CBlockIndex::IsSuperMajorityBit(28, pindex->pprev))) {
+        if (!block.vtx.empty() && (block.vtx[0].nLockTime != pindex->pprev->GetMedianTimePast())) {
+            return state.DoS(100, error("ConnectBlock() : coinbase lock-time not median-time-past"),
+                             REJECT_INVALID, "coinbase-locktime-not-mtp");
+        }
+    }
+
     CBlockUndo blockundo;
 
     CCheckQueueControl<CScriptCheck> control(fScriptChecks && nScriptCheckThreads ? &scriptcheckqueue : NULL);
@@ -2585,6 +2610,12 @@ bool ContextualCheckBlockHeader(const CBlockHeader& block, CValidationState& sta
                              REJECT_OBSOLETE, "bad-version");
     }
 
+    // Reject non-signaling blocks when 95% (75% on testnet) of the network has upgraded
+    // (until timeout activation):
+    if ((pindexPrev->GetMedianTimePast() < Params().VerifyCoinbaseTimelockActivationTime()) && ((block.nVersion >> 28) != 3) && CBlockIndex::IsSuperMajorityBit(28, pindexPrev)) {
+        return state.Invalid(error("AcceptBlock() : rejected non-coinbase-mtp block before activation timeout"));
+    }
+
     return true;
 }
 
@@ -2708,6 +2739,20 @@ bool CBlockIndex::IsSuperMajority(int minVersion, const CBlockIndex* pstart, uns
     for (unsigned int i = 0; i < nToCheck && nFound < nRequired && pstart != NULL; i++)
     {
         if (pstart->nVersion >= minVersion)
+            ++nFound;
+        pstart = pstart->pprev;
+    }
+    return (nFound >= nRequired);
+}
+
+bool CBlockIndex::IsSuperMajorityBit(int bit, const CBlockIndex* pstart)
+{
+    unsigned int nRequired = Params().ActivateBitUpgradeMajority();
+    unsigned int nToCheck = Params().ToCheckBitUpgradeMajority();
+    unsigned int nFound = 0;
+    for (unsigned int i = 0; i < nToCheck && nFound < nRequired && pstart != NULL; i++)
+    {
+        if (((pstart->nVersion >> 29) == 1) && (pstart->nVersion & (1 << bit)))
             ++nFound;
         pstart = pstart->pprev;
     }

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -155,6 +155,9 @@ CBlockTemplate* CreateNewBlock(const CScript& scriptPubKeyIn)
         txNew.nVersion = 2;
         txNew.lock_height = nHeight;
 
+        // Lock-time of coinbase must be median-time-past
+        txNew.nLockTime = pindexPrev->GetMedianTimePast();
+
         // Priority order to process transactions
         list<COrphan> vOrphan; // list memory doesn't move
         map<uint256, vector<COrphan*> > mapDependers;

--- a/src/primitives/block.h
+++ b/src/primitives/block.h
@@ -38,7 +38,7 @@ class CBlockHeader
 {
 public:
     // header
-    static const int32_t CURRENT_VERSION=3;
+    static const int32_t CURRENT_VERSION = (01U << 29) | (1U << 28); // Version bits; #28 set
     int32_t nVersion;
     uint256 hashPrevBlock;
     uint256 hashMerkleRoot;

--- a/src/test/miner_tests.cpp
+++ b/src/test/miner_tests.cpp
@@ -91,6 +91,7 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
         txCoinbase.vin[0].scriptSig << CScriptNum(blockinfo[i].extranonce);
         txCoinbase.vout[0].nValue = 50 * COIN;
         txCoinbase.vout[0].scriptPubKey = CScript();
+        txCoinbase.nLockTime = 0;
         txCoinbase.lock_height = chainActive.Height() + 1;
         pblock->vtx[0] = CTransaction(txCoinbase);
         if (txFirst.size() < 2)


### PR DESCRIPTION
This is an old-style supermajority rollout with BIP8/BIP9-like version bits and BIP8-like activation-on-timeout semantics. It's not strictly compatible with those BIPs though, as we didn't want to back port all the necessary state management code. But miners using BIP8/BIP9 compatible version bit software should work with this rollout by configuring their devices to signal bit #28 (the highest-order BIP8/BIP9 bit).

Fixes #27 .