### PR TITLE
Delay block file size increase until after the protocol cleanup rules activate

### DIFF
--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -218,6 +218,24 @@ Libsecp256k1 has undergone very extensive testing and validation.
 A side effect of this change is that libconsensus no longer depends on
 OpenSSL.
 
+Block file and undo file size
+-----------------------------
+
+v10 introduced the time-delayed protocol-cleanup rule change, which
+required increasing the maximum block file size from 128 MB to nearly
+2GB. This setting controls the size of the blk*.dat and rev*.dat files
+in the `blocks` subdirectory of the Freicoin data directory. Starting
+in v12, the original 128 MB limit is restored until the protocol
+cleanup rule change activates.
+
+Existing files will not be rewritten, however, so if you were at any
+point running a v10 or v11 client prior to 2 April 2021 you may have
+some historical block chain data files that are larger than 128 MB.
+This will not interfere with normal operation of your client. Should
+you wish to split these files up you will need to shutdown your node,
+delete the `blocks` subdirectory, and restart your node to re-download
+and re-index the block chain.
+
 Reduce upload traffic
 ---------------------
 

--- a/src/consensus/consensus.h
+++ b/src/consensus/consensus.h
@@ -22,8 +22,8 @@
 
 /** The maximum allowed size for a serialized block, in bytes (network rule) */
 static const unsigned int MAX_BLOCK_SIZE = 1000000;
-/** The maximum size of a blk?????.dat file (since 0.8) (post-cleanup network rule) */
-static const unsigned int MAX_BLOCKFILE_SIZE = 0x7f000000; // (2048 - 16) MiB
+/** The maximum size of a blk?????.dat file (since v10) (post-cleanup network rule) */
+static const unsigned int PROTOCOL_CLEANUP_MAX_BLOCKFILE_SIZE = 0x7f000000; // (2048 - 16) MiB
 /** The maximum allowed number of signature check operations in a block (network rule) */
 static const unsigned int MAX_BLOCK_SIGOPS = MAX_BLOCK_SIZE/50;
 /** Coinbase transaction outputs can only be spent after this number of new blocks (network rule) */

--- a/src/main.h
+++ b/src/main.h
@@ -76,6 +76,8 @@ static const unsigned int DEFAULT_DESCENDANT_LIMIT = 25;
 static const unsigned int DEFAULT_DESCENDANT_SIZE_LIMIT = 101;
 /** Default for -mempoolexpiry, expiration time for mempool transactions in hours */
 static const unsigned int DEFAULT_MEMPOOL_EXPIRY = 72;
+/** The maximum size of a blk?????.dat file (since 0.8) */
+static const unsigned int MAX_BLOCKFILE_SIZE = 0x8000000; // 128 MiB
 /** The pre-allocation chunk size for blk?????.dat files (since 0.8) */
 static const unsigned int BLOCKFILE_CHUNK_SIZE = 0x1000000; // 16 MiB
 /** The pre-allocation chunk size for rev?????.dat files (since 0.8) */
@@ -272,6 +274,15 @@ inline bool IsProtocolCleanupActive(const Consensus::Params& params, const CBloc
 {
     return ((pindex ? pindex->GetMedianTimePast() : 0) >= params.protocol_cleanup_activation_time);
 }
+/** Finally, a version based on network time, for places in
+ ** non-consensus code where it would be inappropriate to examine the
+ ** chain tip.
+ **/
+inline bool IsProtocolCleanupActive(const Consensus::Params& params, int64_t now)
+{
+    return (now > (params.protocol_cleanup_activation_time - 2*60*60 /* two hours */));
+}
+
 
 struct BlockHasher
 {

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -47,8 +47,6 @@
 #include <miniupnpc/upnperrors.h>
 #endif
 
-#include <algorithm>
-
 #include <boost/filesystem.hpp>
 #include <boost/thread.hpp>
 
@@ -681,44 +679,7 @@ bool CNode::ReceiveMsgBytes(const char *pch, unsigned int nBytes)
         if (handled < 0)
                 return false;
 
-        // Unconstraining the block size in the protocol cleanup fork
-        // means that network message size must also be unconstrained,
-        // which is a potential DoS vector. Unfortunately there is no
-        // easy way around this. Until better tools are available in
-        // future versions, we must accept that after activation of
-        // the protocol cleanup fork we might receive a message up to
-        // the largest possible block size, which is limited only by
-        // MAX_BLOCKFILE_SIZE.
-        //
-        // However this value is dangerously high for 32-bit clients,
-        // as it presents an easy DoS vector for memory exhaustion
-        // attacks. We therefore use a lower limit for 32-bit builds
-        // which prevents exhaustion of the memory address space with
-        // the maximum number of connected peers. This does mean that
-        // 32-bit clients will stop being able to synchronize from the
-        // network once blocks genuinely grow larger than 16MiB. But
-        // as it is doubtful that a true 32-bit peer could keep up
-        // with the network in such an instance, this is deemed an
-        // acceptable tradeoff.
-        size_t max_msg_size = MAX_PROTOCOL_MESSAGE_LENGTH;
-        if (GetAdjustedTime() > (Params().GetConsensus().protocol_cleanup_activation_time - 2*60*60 /* two hours */)) {
-            // Use no more than 2GiB for messages in flight on 32-bit
-            // peers. With the default max of 125 connections this is
-            // slightly more than 16MiB. A 32-bit node operator could
-            // indirectly raise this value by lowering the maximum
-            // number of allowed connections in their configuration
-            // file. But we will not decrease below this amount just
-            // because user configured their node to accept more
-            // inbound peers than the default.
-            size_t max_data_per_peer = numeric_limits<size_t>::max() / std::max(nMaxConnections, 125) / 2;
-            // On 64-bit nodes, the above calculation results in an
-            // enormous number, so we use the lower implicit protocol
-            // rule of the maximum blockfile size--a block larger than
-            // this value could not be stored to disk.
-            max_msg_size = std::min(max_data_per_peer, static_cast<size_t>(MAX_BLOCKFILE_SIZE - 8 + 24));
-        }
-
-        if (msg.in_data && msg.hdr.nMessageSize > max_msg_size) {
+        if (msg.in_data && msg.hdr.nMessageSize > MaxProtocolMessageLength(Params().GetConsensus())) {
             LogPrint("net", "Oversized message from peer=%i, disconnecting\n", GetId());
             return false;
         }
@@ -757,7 +718,7 @@ int CNetMessage::readHeader(const char *pch, unsigned int nBytes)
     }
 
     // reject messages larger than MAX_SIZE
-    if (hdr.nMessageSize > MAX_SIZE)
+    if (hdr.nMessageSize > MaxProtocolMessageLength(Params().GetConsensus()))
             return -1;
 
     // switch state to reading message data

--- a/src/net.h
+++ b/src/net.h
@@ -57,8 +57,6 @@ static const int TIMEOUT_INTERVAL = 20 * 60;
 static const unsigned int MAX_INV_SZ = 50000;
 /** The maximum number of new addresses to accumulate before announcing. */
 static const unsigned int MAX_ADDR_TO_SEND = 1000;
-/** Maximum length of incoming protocol messages (no message over 2 MiB is currently acceptable). */
-static const unsigned int MAX_PROTOCOL_MESSAGE_LENGTH = 2 * 1024 * 1024;
 /** Maximum length of strSubVer in `version` message */
 static const unsigned int MAX_SUBVERSION_LENGTH = 256;
 /** -listen default */

--- a/src/protocol.cpp
+++ b/src/protocol.cpp
@@ -19,8 +19,15 @@
 
 #include "protocol.h"
 
+#include "chainparams.h"
+#include "consensus/consensus.h"
+#include "consensus/params.h"
+#include "timedata.h"
 #include "util.h"
 #include "utilstrencodings.h"
+
+#include <algorithm>
+#include <limits>
 
 #ifndef WIN32
 # include <arpa/inet.h>
@@ -88,6 +95,48 @@ const static std::string allNetMessageTypes[] = {
 };
 const static std::vector<std::string> allNetMessageTypesVec(allNetMessageTypes, allNetMessageTypes+ARRAYLEN(allNetMessageTypes));
 
+extern int nMaxConnections; // declared in net.h
+size_t MaxProtocolMessageLength(const Consensus::Params &params)
+{
+    // Unconstraining the block size in the protocol cleanup fork
+    // means that network message size must also be unconstrained,
+    // which is a potential DoS vector. Unfortunately there is no
+    // easy way around this. Until better tools are available in
+    // future versions, we must accept that after activation of
+    // the protocol cleanup fork we might receive a message up to
+    // the largest possible block size, which is limited only by
+    // PROTOCOL_CLEANUP_MAX_BLOCKFILE_SIZE, which is nearly 2 GiB.
+    //
+    // However this value is dangerously high for 32-bit clients,
+    // as it presents an easy DoS vector for memory exhaustion
+    // attacks. We therefore use a lower limit for 32-bit builds
+    // which prevents exhaustion of the memory address space with
+    // the maximum number of connected peers. This does mean that
+    // 32-bit clients will stop being able to synchronize from the
+    // network once blocks genuinely grow larger than 16 MiB. But
+    // as it is doubtful that a true 32-bit peer could keep up
+    // with the network in such an instance, this is deemed an
+    // acceptable tradeoff.
+    size_t max_msg_size = MAX_PROTOCOL_MESSAGE_LENGTH;
+    if (GetAdjustedTime() > (Params().GetConsensus().protocol_cleanup_activation_time - 2*60*60 /* two hours */)) {
+        // Use no more than 2 GiB for messages in flight on 32-bit
+        // peers. With the default max of 125 connections this is
+        // slightly more than 16 MiB. A 32-bit node operator could
+        // indirectly raise this value by lowering the maximum
+        // number of allowed connections in their configuration
+        // file. But we will not decrease below this amount just
+        // because user configured their node to accept more
+        // inbound peers than the default.
+        size_t max_data_per_peer = std::numeric_limits<size_t>::max() / std::max(nMaxConnections, 125) / 2;
+        // On 64-bit nodes, the above calculation results in an
+        // enormous number, so we use the lower implicit protocol
+        // rule of the maximum blockfile size--a block larger than
+        // this value could not be stored to disk.
+        max_msg_size = std::min(max_data_per_peer, static_cast<size_t>(PROTOCOL_CLEANUP_MAX_BLOCKFILE_SIZE - 8 + 24));
+    }
+    return max_msg_size;
+}
+
 CMessageHeader::CMessageHeader(const MessageStartChars& pchMessageStartIn)
 {
     memcpy(pchMessageStart, pchMessageStartIn, MESSAGE_START_SIZE);
@@ -131,7 +180,7 @@ bool CMessageHeader::IsValid(const MessageStartChars& pchMessageStartIn) const
     }
 
     // Message size
-    if (nMessageSize > MAX_SIZE)
+    if (nMessageSize > MaxProtocolMessageLength(Params().GetConsensus()))
     {
         LogPrintf("CMessageHeader::IsValid(): (%s, %u bytes) nMessageSize > MAX_SIZE\n", GetCommand(), nMessageSize);
         return false;

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -24,6 +24,7 @@
 #ifndef FREICOIN_PROTOCOL_H
 #define FREICOIN_PROTOCOL_H
 
+#include "consensus/params.h"
 #include "netbase.h"
 #include "serialize.h"
 #include "uint256.h"
@@ -33,6 +34,15 @@
 #include <string>
 
 #define MESSAGE_START_SIZE 4
+
+/** Maximum length of incoming protocol messages prior to the protocol
+ ** cleanup rule change, before which no message over 2 MiB is
+ ** acceptable. */
+static const unsigned int MAX_PROTOCOL_MESSAGE_LENGTH = 2 * 1024 * 1024;
+/** The maximum length of an incoming protocol message after taking
+ ** into account whether the protocol cleanup rule change has occured
+ ** (and the number of allowed peers on 32-bit hosts). */
+size_t MaxProtocolMessageLength(const Consensus::Params &params);
 
 /** Message header.
  * (4) message start.

--- a/src/serialize.h
+++ b/src/serialize.h
@@ -37,16 +37,16 @@
 #include "prevector.h"
 
 /**
- * This is set to MAX_BLOCKFILE_SIZE, plus 1.25kB. The largest
- * possible thing that is currently serialized is a relay message for
- * a full block after activation of the protocol-cleanup rule changes,
- * which is limited to MAX_BLOCKFILE_SIZE - 8 + 24 bytes. But it is
- * rather costless to add more than a full kilobyte of extra space
- * just to be sure that we aren't accidentally adding a network
- * synchronization consensus rule now or as a result of future chages.
- * "1.25kB should be enough block metadata for anybody."
+ * This is set to 2*MAX_BLOCK_SIZE, plus 1.25kB. The largest possible
+ * thing that is currently serialized is the submission of a block by
+ * JSON-RPC, which is limited to MAX_BLOCK_SIZE hex-encoded bytes (so,
+ * doubled) plus some JSON formatting. But it is rather costless to
+ * add more than a full kilobyte of extra space just to be sure that
+ * we aren't accidentally adding a network synchronization consensus
+ * rule now or as a result of future chages.  "1.25kB should be enough
+ * block metadata for anybody."
  */
-static const unsigned int MAX_SIZE = 0x7f000500; /* MAX_BLOCKFILE_SIZE + 1.25kB */
+static const unsigned int MAX_SIZE = 0x02000500; /* 2*MAX_BLOCK_SIZE + 1.25kB */
 
 /**
  * Used to bypass the rule against non-const reference to temporary


### PR DESCRIPTION
This is a follow-up to #26. By comparing against `GetAdjustedTime` we can check if we are running in the protocol cleanup regime, and only then use the higher limits for block file size. In the mean time we'll still use smaller block files which is beneficial for pruning.

It's slightly layer violating to access the chain consensus parameters in some cases, e.g. from the network and protocol message handling code. But it doesn't break the build and is better than the alternative.