### PR TITLE
Fix final jsonrpc tests

### DIFF
--- a/qa/pull-tester/rpc-tests.py
+++ b/qa/pull-tester/rpc-tests.py
@@ -126,7 +126,7 @@ testScripts = [
     'nodehandling.py',
     'reindex.py',
     'decodescript.py',
-#    'p2p-fullblocktest.py --bitcoin-mode', #unknown error
+    'p2p-fullblocktest.py --bitcoin-mode',
     'blockchain.py',
     'disablewallet.py',
     'sendheaders.py',

--- a/qa/pull-tester/rpc-tests.py
+++ b/qa/pull-tester/rpc-tests.py
@@ -127,7 +127,7 @@ testScripts = [
     'reindex.py',
     'decodescript.py',
 #    'p2p-fullblocktest.py --bitcoin-mode', #unknown error
-    'blockchain.py --bitcoin-mode',
+    'blockchain.py',
     'disablewallet.py',
     'sendheaders.py',
     'keypool.py',

--- a/qa/rpc-tests/blockchain.py
+++ b/qa/rpc-tests/blockchain.py
@@ -66,7 +66,7 @@ class BlockchainTest(FreicoinTestFramework):
         res = node.gettxoutsetinfo()
 
         assert_equal(res['total_value'], Decimal('10000.00000000'))
-        assert_equal(res['total_amount'], Decimal('10000.00000000'))
+        assert_equal(res['total_amount'], Decimal('9999.04161694'))
         assert_equal(res['transactions'], 200)
         assert_equal(res['height'], 200)
         assert_equal(res['txouts'], 200)

--- a/qa/rpc-tests/blockchain.py
+++ b/qa/rpc-tests/blockchain.py
@@ -65,11 +65,12 @@ class BlockchainTest(FreicoinTestFramework):
         node = self.nodes[0]
         res = node.gettxoutsetinfo()
 
-        assert_equal(res['total_amount'], Decimal('8725.00000000'))
+        assert_equal(res['total_value'], Decimal('10000.00000000'))
+        assert_equal(res['total_amount'], Decimal('10000.00000000'))
         assert_equal(res['transactions'], 200)
         assert_equal(res['height'], 200)
         assert_equal(res['txouts'], 200)
-        assert_equal(res['bytes_serialized'], 14197),
+        assert_equal(res['bytes_serialized'], 14146),
         assert_equal(len(res['bestblock']), 64)
         assert_equal(len(res['hash_serialized']), 64)
 

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -216,7 +216,7 @@ public:
         consensus.initial_excess_subsidy = 15916928404LL; // 1519.1692,8404fc
         consensus.verify_dersig_activation_height = 1;
         consensus.truncate_inputs_activation_height = 1;
-        consensus.alu_activation_height = 2016;
+        consensus.alu_activation_height = 1;
         consensus.nMajorityEnforceBlockUpgrade = 51;
         consensus.nMajorityRejectBlockOutdated = 75;
         consensus.nMajorityWindow = 100;
@@ -306,7 +306,7 @@ public:
         consensus.initial_excess_subsidy = 0;
         consensus.verify_dersig_activation_height = 1;
         consensus.truncate_inputs_activation_height = 1;
-        consensus.alu_activation_height = 150;
+        consensus.alu_activation_height = 1;
         consensus.nMajorityEnforceBlockUpgrade = 750;
         consensus.nMajorityRejectBlockOutdated = 950;
         consensus.nMajorityWindow = 1000;

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -75,6 +75,7 @@ public:
         consensus.equilibrium_height = 161280; // three years
         consensus.equilibrium_monetary_base = 10000000000000000LL; // 100,000,000.0000,0000fc
         consensus.initial_excess_subsidy = 15916928404LL; // 1519.1692,8404fc
+        consensus.truncate_inputs_activation_height = 158425;
         consensus.alu_activation_height = 229376;
         consensus.nMajorityEnforceBlockUpgrade = 750;
         consensus.nMajorityRejectBlockOutdated = 950;
@@ -212,6 +213,7 @@ public:
         consensus.equilibrium_height = 161280; // three years
         consensus.equilibrium_monetary_base = 10000000000000000LL; // 100,000,000.0000,0000fc
         consensus.initial_excess_subsidy = 15916928404LL; // 1519.1692,8404fc
+        consensus.truncate_inputs_activation_height = 1;
         consensus.alu_activation_height = 2016;
         consensus.nMajorityEnforceBlockUpgrade = 51;
         consensus.nMajorityRejectBlockOutdated = 75;
@@ -300,6 +302,7 @@ public:
         consensus.equilibrium_height = 1; // disable
         consensus.equilibrium_monetary_base = 0;
         consensus.initial_excess_subsidy = 0;
+        consensus.truncate_inputs_activation_height = 1;
         consensus.alu_activation_height = 150;
         consensus.nMajorityEnforceBlockUpgrade = 750;
         consensus.nMajorityRejectBlockOutdated = 950;

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -75,6 +75,7 @@ public:
         consensus.equilibrium_height = 161280; // three years
         consensus.equilibrium_monetary_base = 10000000000000000LL; // 100,000,000.0000,0000fc
         consensus.initial_excess_subsidy = 15916928404LL; // 1519.1692,8404fc
+        consensus.verify_dersig_activation_height = 158425;
         consensus.truncate_inputs_activation_height = 158425;
         consensus.alu_activation_height = 229376;
         consensus.nMajorityEnforceBlockUpgrade = 750;
@@ -213,6 +214,7 @@ public:
         consensus.equilibrium_height = 161280; // three years
         consensus.equilibrium_monetary_base = 10000000000000000LL; // 100,000,000.0000,0000fc
         consensus.initial_excess_subsidy = 15916928404LL; // 1519.1692,8404fc
+        consensus.verify_dersig_activation_height = 1;
         consensus.truncate_inputs_activation_height = 1;
         consensus.alu_activation_height = 2016;
         consensus.nMajorityEnforceBlockUpgrade = 51;
@@ -302,6 +304,7 @@ public:
         consensus.equilibrium_height = 1; // disable
         consensus.equilibrium_monetary_base = 0;
         consensus.initial_excess_subsidy = 0;
+        consensus.verify_dersig_activation_height = 1;
         consensus.truncate_inputs_activation_height = 1;
         consensus.alu_activation_height = 150;
         consensus.nMajorityEnforceBlockUpgrade = 750;

--- a/src/coins.h
+++ b/src/coins.h
@@ -340,6 +340,7 @@ struct CCoinsStats
     uint64_t nTransactionOutputs;
     uint64_t nSerializedSize;
     uint256 hashSerialized;
+    CAmount nTotalValue;
     CAmount nTotalAmount;
 
     CCoinsStats() : nHeight(0), nTransactions(0), nTransactionOutputs(0), nSerializedSize(0), nTotalAmount(0) {}

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -60,6 +60,7 @@ struct Params {
     int64_t equilibrium_monetary_base;
     CAmount initial_excess_subsidy;
     /** Soft-fork activations */
+    int64_t verify_dersig_activation_height;
     int64_t truncate_inputs_activation_height;
     int64_t alu_activation_height;
     int64_t verify_coinbase_lock_time_activation_height;

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -60,6 +60,7 @@ struct Params {
     int64_t equilibrium_monetary_base;
     CAmount initial_excess_subsidy;
     /** Soft-fork activations */
+    int64_t truncate_inputs_activation_height;
     int64_t alu_activation_height;
     int64_t verify_coinbase_lock_time_activation_height;
     int64_t verify_coinbase_lock_time_timeout;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2293,10 +2293,6 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
     int64_t nBIP16SwitchTime = 1333238400;
     bool fStrictPayToScriptHash = (pindex->GetBlockTime() >= nBIP16SwitchTime);
 
-    // Whether fractional inputs should be summed or ignored. Bundled as part of the
-    // BIP66 soft-fork in Freicoin.
-    bool truncate_inputs = false;
-
     unsigned int flags = fStrictPayToScriptHash ? SCRIPT_VERIFY_P2SH : SCRIPT_VERIFY_NONE;
     if (protocol_cleanup) {
         flags |= SCRIPT_VERIFY_PROTOCOL_CLEANUP;
@@ -2306,6 +2302,11 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
     // when 75% of the network has upgraded:
     if (protocol_cleanup || (block.nVersion >= 3 && IsSuperMajority(3, pindex->pprev, chainparams.GetConsensus().nMajorityEnforceBlockUpgrade, chainparams.GetConsensus()))) {
         flags |= SCRIPT_VERIFY_DERSIG;
+    }
+
+    // Whether fractional inputs should be summed or ignored.
+    bool truncate_inputs = false;
+    if (pindex->nHeight >= chainparams.GetConsensus().truncate_inputs_activation_height) {
         truncate_inputs = true;
     }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2300,7 +2300,7 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
 
     // Start enforcing the DERSIG (BIP66) rules, for block.nVersion=3 blocks,
     // when 75% of the network has upgraded:
-    if (protocol_cleanup || (block.nVersion >= 3 && IsSuperMajority(3, pindex->pprev, chainparams.GetConsensus().nMajorityEnforceBlockUpgrade, chainparams.GetConsensus()))) {
+    if (pindex->nHeight >= chainparams.GetConsensus().verify_dersig_activation_height) {
         flags |= SCRIPT_VERIFY_DERSIG;
     }
 

--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -475,6 +475,7 @@ UniValue gettxoutsetinfo(const UniValue& params, bool fHelp)
         ret.push_back(Pair("txouts", (int64_t)stats.nTransactionOutputs));
         ret.push_back(Pair("bytes_serialized", (int64_t)stats.nSerializedSize));
         ret.push_back(Pair("hash_serialized", stats.hashSerialized.GetHex()));
+        ret.push_back(Pair("total_value", ValueFromAmount(stats.nTotalValue)));
         ret.push_back(Pair("total_amount", ValueFromAmount(stats.nTotalAmount)));
     }
     return ret;

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -153,6 +153,7 @@ bool CCoinsViewDB::GetStats(CCoinsStats &stats) const {
         stats.nHeight = mapBlockIndex.find(stats.hashBlock)->second->nHeight;
     }
     stats.hashSerialized = ss.GetHash();
+    stats.nTotalValue = nTotalValue;
     stats.nTotalAmount = nTotalAmount;
     return true;
 }


### PR DESCRIPTION
Re-enables the final set of tests disabled by the demurrage patch set. The problem here was not just demurrage but also the fact that the input truncation and ALU demurrage soft-forks hadn't activated on the regtest chain.