### PR TITLE
Add support for BIP98: fast Merkle trees and proof structures

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -268,6 +268,8 @@ libfreicoin_consensus_a_SOURCES = \
   arith_uint256.h \
   consensus/merkle.cpp \
   consensus/merkle.h \
+  consensus/merkleproof.cpp \
+  consensus/merkleproof.h \
   consensus/params.h \
   consensus/validation.h \
   hash.cpp \

--- a/src/consensus/merkle.cpp
+++ b/src/consensus/merkle.cpp
@@ -61,7 +61,7 @@ typedef enum {
     MERKLE_COMPUTATION_FAST    = 0x2
 } merklecomputationopts;
 
-static void MerkleHash_Hash256(uint256& parent, const uint256& left, const uint256& right) {
+void MerkleHash_Hash256(uint256& parent, const uint256& left, const uint256& right) {
     CHash256().Write(left.begin(), 32).Write(right.begin(), 32).Finalize(parent.begin());
 }
 
@@ -78,7 +78,7 @@ static unsigned char _MidstateIV[32] =
       0xe7, 0x6c, 0xd4, 0x01, 0x68, 0x21, 0x8d, 0x36,
       0x18, 0xd0, 0x9b, 0xe1, 0x9a, 0x7b, 0xff, 0xc0,
       0xec, 0x1d, 0xcc, 0xf0, 0x8f, 0x77, 0x5b, 0xbd };
-static void MerkleHash_Sha256Midstate(uint256& parent, const uint256& left, const uint256& right) {
+void MerkleHash_Sha256Midstate(uint256& parent, const uint256& left, const uint256& right) {
     CSHA256(_MidstateIV).Write(left.begin(), 32).Write(right.begin(), 32).Midstate(parent.begin(), NULL, NULL);
 }
 
@@ -203,44 +203,67 @@ uint256 ComputeMerkleRootFromBranch(const uint256& leaf, const std::vector<uint2
 }
 
 uint256 ComputeFastMerkleRoot(const std::vector<uint256>& leaves) {
-    uint256 hash;
     if (leaves.empty()) {
-        hash = CHashWriter(SER_GETHASH, PROTOCOL_VERSION).GetHash();
-    } else {
-        MerkleComputation(leaves, &hash, NULL, -1, NULL, MERKLE_COMPUTATION_FAST);
+        return CHashWriter(SER_GETHASH, PROTOCOL_VERSION).GetHash();
     }
+    uint256 hash;
+    MerkleComputation(leaves, &hash, NULL, -1, NULL, MERKLE_COMPUTATION_FAST);
     return hash;
 }
 
 std::pair<std::vector<uint256>, uint32_t> ComputeFastMerkleBranch(const std::vector<uint256>& leaves, uint32_t position) {
     std::vector<uint256> branch;
     MerkleComputation(leaves, NULL, NULL, position, &branch, MERKLE_COMPUTATION_FAST);
+    /* Calculate the largest possible size the branch vector can be.
+     * This is one more than the zero-based index of the highest set
+     * bit. */
     std::size_t max = 0;
-    for (int i = 0; i < 32; ++i)
-        if (position & ((uint32_t)1)<<i)
-            max = i + 1;
+    for (max = 32; max > 0; --max)
+        if (position & ((uint32_t)1)<<(max-1))
+            break;
+    /* If the number of returned hashes in the branch vector is less
+     * than the maximum allowed size, it must be because the branch
+     * lies at least partially along the right-most path of an
+     * unbalanced tree.
+     *
+     * We calculate the path by dropping the necessary number of
+     * most-significant zero bits from the binary representation of
+     * position. */
     uint32_t path = position;
     while (max > branch.size()) {
+        /* Find the first clear/zero bit *below* the most significant
+         * set bit.  We do this by starting with what we know to be
+         * the most-significant set bit, and then working backwards
+         * until we hit a zero bit. */
         int i;
         for (i = max-1; i >= 0; --i)
             if (!(path & ((uint32_t)1)<<i))
                 break;
+        /* It will never be the case that we don't find a zero bit as
+         * in that situation MerkleComputation would have returned
+         * more hashes.  However for the purpose helping code analysis
+         * tools which can't make this inference, we detect failure
+         * and return. */
         if (i < 0) // Should never happen
             return {};
-        path = ((path & ~((((uint32_t)1)<<(i+1))-1))>>1)
-             |  (path &  ((((uint32_t)1)<< i   )-1));
-        --max;
-    }
+        /* Bit-fiddle to build two masks: one covering all the bits
+         * above the i'th position, and one covering all bits below.
+         * Apply both to path and shift the top bits down by one
+         * position, effectively eliminating the i'th bit. */
+        path = ((path & ~((((uint32_t)1)<<(i+1))-1))>>1) // e.g. 0b11111111111111111111111100000000
+             |  (path &  ((((uint32_t)1)<< i   )-1));    //      0b00000000000000000000000001111111
+        --max;                                           //                                |
+    }                                                    //                        i = 7 --^
     return {branch, path};
 }
 
 uint256 ComputeFastMerkleRootFromBranch(const uint256& leaf, const std::vector<uint256>& branch, uint32_t path) {
     uint256 hash = leaf;
-    for (std::vector<uint256>::const_iterator it = branch.begin(); it != branch.end(); ++it) {
+    for (const uint256& h : branch) {
         if (path & 1) {
-            MerkleHash_Sha256Midstate(hash, *it, hash);
+            MerkleHash_Sha256Midstate(hash, h, hash);
         } else {
-            MerkleHash_Sha256Midstate(hash, hash, *it);
+            MerkleHash_Sha256Midstate(hash, hash, h);
         }
         path >>= 1;
     }

--- a/src/consensus/merkle.cpp
+++ b/src/consensus/merkle.cpp
@@ -65,19 +65,19 @@ void MerkleHash_Hash256(uint256& parent, const uint256& left, const uint256& rig
     CHash256().Write(left.begin(), 32).Write(right.begin(), 32).Finalize(parent.begin());
 }
 
-/* Calculated by using standard FIPS-180 SHA-256 to hash the first 512
- * bits of the fractional part of the square root of 2 then extracting
- * the midstate. This initial data, expressed in hexadecimal notation
- * is:
+/* Calculated by using standard FIPS-180 SHA-256 to produce the digest of the
+ * empty string / zero-length byte array, then feeding the resulting digest into
+ * SHA-256 twice in order to fill a block and trigger a compression round.  The
+ * midstate is then extracted and used as our hash value.  Expressed with the
+ * pure-Python sha256 package, this would be something like the following:
  *
- *   6a09e667f3bcc908 b2fb1366ea957d3e 3adec17512775099 da2f590b0667322a
- *   95f9060875714587 5163fcdfb907b672 1ee950bc8738f694 f0090e6c7bf44ed1
+ *   iv = sha256(sha256().digest() + sha256().digest()).state[0]
  */
 static unsigned char _MidstateIV[32] =
-    { 0x91, 0x06, 0x6c, 0x2b, 0x97, 0x5c, 0xc8, 0x32,
-      0xe7, 0x6c, 0xd4, 0x01, 0x68, 0x21, 0x8d, 0x36,
-      0x18, 0xd0, 0x9b, 0xe1, 0x9a, 0x7b, 0xff, 0xc0,
-      0xec, 0x1d, 0xcc, 0xf0, 0x8f, 0x77, 0x5b, 0xbd };
+    { 0x1e, 0x4e, 0x0f, 0x95, 0x5a, 0x4b, 0xc8, 0x1c,
+      0x08, 0xc8, 0xaf, 0x1c, 0x94, 0xf3, 0x4b, 0x9d,
+      0x0a, 0xf2, 0xf4, 0x50, 0xdc, 0x24, 0xa3, 0xbc,
+      0xef, 0x98, 0x31, 0x8f, 0xaf, 0x5e, 0x25, 0x06 };
 void MerkleHash_Sha256Midstate(uint256& parent, const uint256& left, const uint256& right) {
     CSHA256(_MidstateIV).Write(left.begin(), 32).Write(right.begin(), 32).Midstate(parent.begin(), NULL, NULL);
 }

--- a/src/consensus/merkle.cpp
+++ b/src/consensus/merkle.cpp
@@ -56,13 +56,44 @@
        root.
 */
 
+typedef enum {
+    MERKLE_COMPUTATION_MUTABLE = 0x1,
+    MERKLE_COMPUTATION_FAST    = 0x2
+} merklecomputationopts;
+
+static void MerkleHash_Hash256(uint256& parent, const uint256& left, const uint256& right) {
+    CHash256().Write(left.begin(), 32).Write(right.begin(), 32).Finalize(parent.begin());
+}
+
+/* Calculated by using standard FIPS-180 SHA-256 to hash the first 512
+ * bits of the fractional part of the square root of 2 then extracting
+ * the midstate. This initial data, expressed in hexadecimal notation
+ * is:
+ *
+ *   6a09e667f3bcc908 b2fb1366ea957d3e 3adec17512775099 da2f590b0667322a
+ *   95f9060875714587 5163fcdfb907b672 1ee950bc8738f694 f0090e6c7bf44ed1
+ */
+static unsigned char _MidstateIV[32] =
+    { 0x91, 0x06, 0x6c, 0x2b, 0x97, 0x5c, 0xc8, 0x32,
+      0xe7, 0x6c, 0xd4, 0x01, 0x68, 0x21, 0x8d, 0x36,
+      0x18, 0xd0, 0x9b, 0xe1, 0x9a, 0x7b, 0xff, 0xc0,
+      0xec, 0x1d, 0xcc, 0xf0, 0x8f, 0x77, 0x5b, 0xbd };
+static void MerkleHash_Sha256Midstate(uint256& parent, const uint256& left, const uint256& right) {
+    CSHA256(_MidstateIV).Write(left.begin(), 32).Write(right.begin(), 32).Midstate(parent.begin(), NULL, NULL);
+}
+
 /* This implements a constant-space merkle root/path calculator, limited to 2^32 leaves. */
-static void MerkleComputation(const std::vector<uint256>& leaves, uint256* proot, bool* pmutated, uint32_t branchpos, std::vector<uint256>* pbranch) {
+static void MerkleComputation(const std::vector<uint256>& leaves, uint256* proot, bool* pmutated, uint32_t branchpos, std::vector<uint256>* pbranch, merklecomputationopts flags) {
     if (pbranch) pbranch->clear();
     if (leaves.size() == 0) {
         if (pmutated) *pmutated = false;
         if (proot) *proot = uint256();
         return;
+    }
+    bool is_mutable = flags & MERKLE_COMPUTATION_MUTABLE;
+    auto MerkleHash = MerkleHash_Hash256;
+    if (flags & MERKLE_COMPUTATION_FAST) {
+        MerkleHash = MerkleHash_Sha256Midstate;
     }
     bool mutated = false;
     // count is the number of leaves processed so far.
@@ -94,7 +125,7 @@ static void MerkleComputation(const std::vector<uint256>& leaves, uint256* proot
                 }
             }
             mutated |= (inner[level] == h);
-            CHash256().Write(inner[level].begin(), 32).Write(h.begin(), 32).Finalize(h.begin());
+            MerkleHash(h, inner[level], h);
         }
         // Store the resulting hash at inner position level.
         inner[level] = h;
@@ -117,10 +148,12 @@ static void MerkleComputation(const std::vector<uint256>& leaves, uint256* proot
         // If we reach this point, h is an inner value that is not the top.
         // We combine it with itself (Freicoin's special rule for odd levels in
         // the tree) to produce a higher level one.
-        if (pbranch && matchh) {
+        if (is_mutable && pbranch && matchh) {
             pbranch->push_back(h);
         }
-        CHash256().Write(h.begin(), 32).Write(h.begin(), 32).Finalize(h.begin());
+        if (is_mutable) {
+            MerkleHash(h, h, h);
+        }
         // Increment count to the value it would have if two entries at this
         // level had existed.
         count += (((uint32_t)1) << level);
@@ -135,7 +168,7 @@ static void MerkleComputation(const std::vector<uint256>& leaves, uint256* proot
                     matchh = true;
                 }
             }
-            CHash256().Write(inner[level].begin(), 32).Write(h.begin(), 32).Finalize(h.begin());
+            MerkleHash(h, inner[level], h);
             level++;
         }
     }
@@ -146,13 +179,13 @@ static void MerkleComputation(const std::vector<uint256>& leaves, uint256* proot
 
 uint256 ComputeMerkleRoot(const std::vector<uint256>& leaves, bool* mutated) {
     uint256 hash;
-    MerkleComputation(leaves, &hash, mutated, -1, NULL);
+    MerkleComputation(leaves, &hash, mutated, -1, NULL, MERKLE_COMPUTATION_MUTABLE);
     return hash;
 }
 
 std::vector<uint256> ComputeMerkleBranch(const std::vector<uint256>& leaves, uint32_t position) {
     std::vector<uint256> ret;
-    MerkleComputation(leaves, NULL, NULL, position, &ret);
+    MerkleComputation(leaves, NULL, NULL, position, &ret, MERKLE_COMPUTATION_MUTABLE);
     return ret;
 }
 
@@ -165,6 +198,51 @@ uint256 ComputeMerkleRootFromBranch(const uint256& leaf, const std::vector<uint2
             hash = Hash(BEGIN(hash), END(hash), BEGIN(*it), END(*it));
         }
         nIndex >>= 1;
+    }
+    return hash;
+}
+
+uint256 ComputeFastMerkleRoot(const std::vector<uint256>& leaves) {
+    uint256 hash;
+    if (leaves.empty()) {
+        hash = CHashWriter(SER_GETHASH, PROTOCOL_VERSION).GetHash();
+    } else {
+        MerkleComputation(leaves, &hash, NULL, -1, NULL, MERKLE_COMPUTATION_FAST);
+    }
+    return hash;
+}
+
+std::pair<std::vector<uint256>, uint32_t> ComputeFastMerkleBranch(const std::vector<uint256>& leaves, uint32_t position) {
+    std::vector<uint256> branch;
+    MerkleComputation(leaves, NULL, NULL, position, &branch, MERKLE_COMPUTATION_FAST);
+    std::size_t max = 0;
+    for (int i = 0; i < 32; ++i)
+        if (position & ((uint32_t)1)<<i)
+            max = i + 1;
+    uint32_t path = position;
+    while (max > branch.size()) {
+        int i;
+        for (i = max-1; i >= 0; --i)
+            if (!(path & ((uint32_t)1)<<i))
+                break;
+        if (i < 0) // Should never happen
+            return {};
+        path = ((path & ~((((uint32_t)1)<<(i+1))-1))>>1)
+             |  (path &  ((((uint32_t)1)<< i   )-1));
+        --max;
+    }
+    return {branch, path};
+}
+
+uint256 ComputeFastMerkleRootFromBranch(const uint256& leaf, const std::vector<uint256>& branch, uint32_t path) {
+    uint256 hash = leaf;
+    for (std::vector<uint256>::const_iterator it = branch.begin(); it != branch.end(); ++it) {
+        if (path & 1) {
+            MerkleHash_Sha256Midstate(hash, *it, hash);
+        } else {
+            MerkleHash_Sha256Midstate(hash, hash, *it);
+        }
+        path >>= 1;
     }
     return hash;
 }

--- a/src/consensus/merkle.h
+++ b/src/consensus/merkle.h
@@ -26,6 +26,9 @@
 #include "primitives/block.h"
 #include "uint256.h"
 
+void MerkleHash_Hash256(uint256& parent, const uint256& left, const uint256& right);
+void MerkleHash_Sha256Midstate(uint256& parent, const uint256& left, const uint256& right);
+
 uint256 ComputeMerkleRoot(const std::vector<uint256>& leaves, bool* mutated = NULL);
 std::vector<uint256> ComputeMerkleBranch(const std::vector<uint256>& leaves, uint32_t position);
 uint256 ComputeMerkleRootFromBranch(const uint256& leaf, const std::vector<uint256>& branch, uint32_t position);

--- a/src/consensus/merkle.h
+++ b/src/consensus/merkle.h
@@ -31,6 +31,104 @@ std::vector<uint256> ComputeMerkleBranch(const std::vector<uint256>& leaves, uin
 uint256 ComputeMerkleRootFromBranch(const uint256& leaf, const std::vector<uint256>& branch, uint32_t position);
 
 /*
+ * Has similar API semantics, but produces Merkle roots and validates
+ * branches 2.32x as fast as the Satoshi Merkle tree, and without the
+ * mutation vulnerability.  ComputeFastMerkleBranch returns a pair
+ * with the second element being the path used to validate the branch.
+ * Cannot be substituted for the non-fast variants because the output
+ * hash values are different.
+ *
+ * In order to avoid unnecessary hash operations, and to fix the
+ * CVE-2012-2459 vulnerability the fast Merkle tree operations do not
+ * produce balanced binary tree unless the number of leaves given is a
+ * power of 2.  It produces instead a tree where the root node's left
+ * branch is to the largest power-of-2 subtree that can be constructed
+ * with the first 2^N elements, and the remainder to the right.  The
+ * node pointed to by the right branch has the largest possible
+ * power-of-2 subtree of the remaining elements to its left, and the
+ * remainder to its right.  This continues recursively until there is
+ * a single leaf element on the far-rightmost branch.
+ *
+ * Alternatively it might be helpful to think of how ComputeMerkleRoot
+ * would contrast with ComputeFastMerkleRoot if the old Satoshi tree
+ * hashing algorithm were used:
+ *
+ * ComputeMerkleRoot essentially compressed its leaves vector by
+ * replacing adjacent entries with their combined hash, and recursing
+ * until only a single element remained.  When the number of leaf or
+ * inner node hashes in the vector was an odd number greater than one,
+ * the final element was hashed with itself.  The result could be
+ * viewed as a perfectly balanced binary tree with some of the final
+ * elements repreated when the size is not a power of 2.
+ *
+ * ComputeFastMerkleRoot, on the other hand, would be implemented by
+ * *not* duplicating the final element when the size of the list is
+ * odd.  This causes the right-side of the tree to be unbalanced when
+ * the number of leaves is not a power of 2.
+ *
+ * With ComputeMerkleBranch and ComputeMerkleRootFromBranch, the path
+ * from the leaf to the root of the tree is given by the binary
+ * encoding of the leaf's position: 0 for left and 1 for right,
+ * starting from the least significant bit and working upwards until
+ * you run out of hashes.
+ *
+ * With the fast Merkle tree variants the path used to validate a
+ * branch is derived from but not necessarily the same as the binary
+ * representation of the original position in the list.
+ * ComputeFastMerkleBranch calculates the path by dropping high-order
+ * zeros from the binary representation of the position until the path
+ * is the same length or less as the number of Merkle branches taken
+ * to reach the node.
+ *
+ * To understand why this works, consider a list of 303 elements from
+ * which a fast Merkle tree is constructed, and we request the branch to
+ * the 292nd element. The binary encoded positions of the last and
+ * desired elements are as follows:
+ *
+ *   0b 1 0 0 1 0 1 1 1 0 # decimal 302 (zero-indexed)
+ *
+ *   0b 1 0 0 1 0 0 0 1 1 # decimal 291
+ *
+ * The root of the Merkle tree has a left branch that contains 2^8 = 256
+ * elements, and a right branch that contains the remaining 47. The first
+ * level of the right branch contains 2^5 = 32 nodes on the left side, and
+ * the remaining 15 nodes on the right side. The next level contains 2^3 =
+ * 8 nodes on the left, and the remaining 7 on the right. This pattern
+ * repeats on the right hand side of the tree: each layer has the largest
+ * remaining power of two on the left, and the residual on the right.
+ *
+ * Notice specifically that the sizes of the sub-trees correspnd to the
+ * set bits in the zero-based index of the final element. For each 1 at,
+ * index n, there is a branch with 2^n elements on the left and the
+ * remaining amount on the right.
+ *
+ * So, for an element whose path traverse the right-side of the tree, the
+ * intervening levels (e.g. 2^7 and 2^6) are missing. These correspond to
+ * zeros in the binary expansion, and they are removed from the path
+ * description. However once the path takes a left-turn into the tree (a
+ * zero where a one is present in the expansion of the last element), the
+ * sub-tree is full and no more 0's can be pruned out.
+ *
+ * So the path for element 292 becomes:
+ *
+ *     0b 1 - - 1 - 0 0 1 1 # decimal 291
+ *
+ *   = 0b 1 1 0 0 1 1
+ *
+ *   = 51
+ *
+ * This path value is calculated and returned alongside the vector of
+ * hashes representing the branch in the return value of
+ * ComputeFastMerkleRoot.
+ *
+ * This path value, and *not* the original position value, should be
+ * used in later calls to ComputeFastMerkleRootFromBranch.
+ */
+uint256 ComputeFastMerkleRoot(const std::vector<uint256>& leaves);
+std::pair<std::vector<uint256>, uint32_t> ComputeFastMerkleBranch(const std::vector<uint256>& leaves, uint32_t position);
+uint256 ComputeFastMerkleRootFromBranch(const uint256& leaf, const std::vector<uint256>& branch, uint32_t path);
+
+/*
  * Compute the Merkle root of the transactions in a block.
  * *mutated is set to true if a duplicated subtree was found.
  */

--- a/src/consensus/merkleproof.cpp
+++ b/src/consensus/merkleproof.cpp
@@ -1,0 +1,323 @@
+// Copyright (c) 2017-2019 The Freicoin Developers
+//
+// This program is free software: you can redistribute it and/or
+// modify it under the conjunctive terms of BOTH version 3 of the GNU
+// Affero General Public License as published by the Free Software
+// Foundation AND the MIT/X11 software license.
+//
+// This program is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Affero General Public License and the MIT/X11 software license for
+// more details.
+//
+// You should have received a copy of both licenses along with this
+// program.  If not, see <https://www.gnu.org/licenses/> and
+// <http://www.opensource.org/licenses/mit-license.php>
+
+#include "hash.h"
+#include "merkleproof.h"
+#include "version.h"
+
+extern void MerkleHash_Sha256Midstate(uint256& parent, const uint256& left, const uint256& right);
+
+/*
+ * The {SKIP, SKIP} entry is missing on purpose. Not only does this
+ * make the number of possible states a nicely packable power of 2,
+ * but excluding that fully prunable state means that any given fully
+ * expanded tree and set of verify hashes has one and only one proof
+ * encoding -- the serialized tree with all {SKIP, SKIP} nodes
+ * recursively pruned.
+ *
+ * The ordering of these entries is also specially chosen: it allows
+ * for lexigraphical ordering of proofs extracted from the same tree
+ * to stand-in for lexigraphical ordering of the underlying elements
+ * if interpreted as an ordered list.
+ */
+const std::array<MerkleLink, 8> MerkleNode::m_left_from_code {{
+    MerkleLink::VERIFY,  MerkleLink::VERIFY,  MerkleLink::VERIFY,
+    MerkleLink::DESCEND, MerkleLink::DESCEND, MerkleLink::DESCEND,
+      /* No SKIP */      MerkleLink::SKIP,    MerkleLink::SKIP }};
+
+const std::array<MerkleLink, 8> MerkleNode::m_right_from_code {{
+    MerkleLink::SKIP, MerkleLink::VERIFY, MerkleLink::DESCEND,
+    MerkleLink::SKIP, MerkleLink::VERIFY, MerkleLink::DESCEND,
+      /* No SKIP */   MerkleLink::VERIFY, MerkleLink::DESCEND }};
+
+MerkleNode::code_type MerkleNode::_encode(MerkleLink left, MerkleLink right)
+{
+    /* Returns the 3-bit code for a given combination of left and
+     * right link values in an internal node. */
+    code_type code = std::numeric_limits<code_type>::max();
+    /* Write out a table of Code values to see why this works :) */
+    switch (left)
+    {
+        case MerkleLink::DESCEND: code = 5; break;
+        case MerkleLink::VERIFY:  code = 2; break;
+        case MerkleLink::SKIP:    code = 7; break;
+    }
+    switch (right)
+    {
+        case MerkleLink::SKIP:    --code; // No break!
+        case MerkleLink::VERIFY:  --code; break;
+        case MerkleLink::DESCEND:         break;
+    }
+    return code;
+}
+
+MerkleNode::code_type MerkleNodeReference::GetCode() const
+{
+    /* Belts and suspenders: m_offset should never be anything outside
+     * the range [0, 7], so the assignment to max, which is necessary
+     * to avoid compiler whining, should be undone by the switch that
+     * follows.  But just in case we'll favor failing in a way that is
+     * maximally likely to be cause trouble when the code value is
+     * later used. */
+    MerkleNode::code_type code = std::numeric_limits<MerkleNode::code_type>::max();
+    switch (m_offset)
+    {
+        /* Use the diagram in the class definition to work out that
+         * these magic constant values are correct. */
+        case 0: code =   m_base[0] >> 5;       break;
+        case 1: code =   m_base[0] >> 2;       break;
+        case 2: code =  (m_base[0] << 1)
+                     | ((m_base[1] >> 7) & 1); break;
+        case 3: code =   m_base[1] >> 4;       break;
+        case 4: code =   m_base[1] >> 1;       break;
+        case 5: code =  (m_base[1] << 2)
+                     | ((m_base[2] >> 6) & 3); break;
+        case 6: code =   m_base[2] >> 3;       break;
+        case 7: code =   m_base[2];            break;
+        /* offset should never be outside the range of [0, 7], so we
+         * should have been handled by one of the prior conditions and
+         * this code is unreachable.  But as a matter of defensive
+         * coding we throw a runtime error rather than return a
+         * nonsense value. */
+        default:
+            throw std::runtime_error("MerkleNode::m_offset out of bounds");
+    }
+    return code & 7;
+}
+
+MerkleNodeReference& MerkleNodeReference::SetCode(MerkleNode::code_type code)
+{
+    switch (m_offset)
+    {
+        /* Again, check the diagram in the class definition to see
+         * where these magic constant shift and mask values arise
+         * from. */
+        case 0: m_base[0] = (m_base[0] & 0x1f) |  (code      << 5); break;
+        case 1: m_base[0] = (m_base[0] & 0xe3) |  (code      << 2); break;
+        case 2: m_base[0] = (m_base[0] & 0xfc) |  (code      >> 1);
+                m_base[1] = (m_base[1] & 0x7f) | ((code & 1) << 7); break;
+        case 3: m_base[1] = (m_base[1] & 0x8f) |  (code      << 4); break;
+        case 4: m_base[1] = (m_base[1] & 0xf1) |  (code      << 1); break;
+        case 5: m_base[1] = (m_base[1] & 0xfe) |  (code      >> 2);
+                m_base[2] = (m_base[2] & 0x3f) | ((code & 3) << 6); break;
+        case 6: m_base[2] = (m_base[2] & 0xc7) |  (code      << 3); break;
+        case 7: m_base[2] = (m_base[2] & 0xf8) |   code;            break;
+        /* offset should never be outside the range of [0, 7], so we
+         * should have been handled by one of the prior conditions and
+         * this code is unreachable.  But as a matter of defensive
+         * coding we throw a runtime error rather than try to guess
+         * why we got here. */
+        default:
+            throw std::runtime_error("MerkleNode::m_offset out of bounds");
+    }
+    return *this;
+}
+
+void MerkleNodeIteratorBase::_incr()
+{
+    if (m_ref.m_offset++ == 7) {
+        m_ref.m_offset = 0;
+        m_ref.m_base += 3;
+    }
+}
+
+void MerkleNodeIteratorBase::_decr()
+{
+    if (m_ref.m_offset-- == 0) {
+        m_ref.m_offset = 7;
+        m_ref.m_base -= 3;
+    }
+}
+
+void MerkleNodeIteratorBase::_seek(MerkleNodeIteratorBase::difference_type distance)
+{
+    difference_type bits = distance + m_ref.m_offset;
+    m_ref.m_base += 3 * (bits / 8);
+    bits = bits % 8;
+    if (bits < 0) {
+        bits += 8;
+        m_ref.m_base -= 3;
+    }
+    m_ref.m_offset = static_cast<MerkleNodeReference::offset_type>(bits);
+}
+
+MerkleNodeIteratorBase::difference_type MerkleNodeIteratorBase::operator-(const MerkleNodeIteratorBase& other) const
+{
+    /* Compare with the version of _seek implemented above. The
+     * following property should hold true:
+     *
+     *   A._seek(B-A) == B
+     *
+     * That is to say, the difference between two iterators is the
+     * value which needs to be passed to _seek() to move from one to
+     * the other. */
+    return 8 * (m_ref.m_base - other.m_ref.m_base) / 3 + m_ref.m_offset - other.m_ref.m_offset;
+}
+
+void MerkleProof::clear() noexcept
+{
+    m_path.clear();
+    m_skip.clear();
+}
+
+void swap(MerkleProof& lhs, MerkleProof& rhs)
+{
+    using std::swap;
+    swap(lhs.m_path, rhs.m_path);
+    swap(lhs.m_skip, rhs.m_skip);
+}
+
+MerkleTree::MerkleTree(const MerkleTree& left, const MerkleTree& right)
+{
+    /* Handle the special case of both left and right being fully
+     * pruned, which also results in a fully pruned super-tree. */
+    if (left.m_proof.m_path.empty() && left.m_proof.m_skip.size()==1 && left.m_verify.empty() &&
+        right.m_proof.m_path.empty() && right.m_proof.m_skip.size()==1 && right.m_verify.empty())
+    {
+        m_proof.m_skip.resize(1);
+        MerkleHash_Sha256Midstate(m_proof.m_skip[0], left.m_proof.m_skip[0], right.m_proof.m_skip[0]);
+        return;
+    }
+
+    /* We assume a well-formed, non-empty MerkleTree for both passed
+     * in subtrees, in which if there are no internal nodes than
+     * either m_skip XOR m_verify must have a single hash.  Otherwise
+     * the result of what follows will be an invalid MerkleTree. */
+    m_proof.m_path.emplace_back(MerkleLink::DESCEND, MerkleLink::DESCEND);
+
+    if (left.m_proof.m_path.empty())
+        m_proof.m_path.front().SetLeft(left.m_proof.m_skip.empty()? MerkleLink::VERIFY: MerkleLink::SKIP);
+    m_proof.m_path.insert(m_proof.m_path.end(), left.m_proof.m_path.begin(), left.m_proof.m_path.end());
+    m_proof.m_skip.insert(m_proof.m_skip.end(), left.m_proof.m_skip.begin(), left.m_proof.m_skip.end());
+    m_verify.insert(m_verify.end(), left.m_verify.begin(), left.m_verify.end());
+
+    if (right.m_proof.m_path.empty())
+        m_proof.m_path.front().SetRight(right.m_proof.m_skip.empty()? MerkleLink::VERIFY: MerkleLink::SKIP);
+    m_proof.m_path.insert(m_proof.m_path.end(), right.m_proof.m_path.begin(), right.m_proof.m_path.end());
+    m_proof.m_skip.insert(m_proof.m_skip.end(), right.m_proof.m_skip.begin(), right.m_proof.m_skip.end());
+    m_verify.insert(m_verify.end(), right.m_verify.begin(), right.m_verify.end());
+}
+
+void MerkleTree::clear() noexcept
+{
+    m_proof.clear();
+    m_verify.clear();
+}
+
+void swap(MerkleTree& lhs, MerkleTree& rhs)
+{
+    using std::swap;
+    swap(lhs.m_proof, rhs.m_proof);
+    swap(lhs.m_verify, rhs.m_verify);
+}
+
+uint256 MerkleTree::GetHash(bool* invalid) const
+{
+    std::vector<std::pair<bool, uint256> > stack(2);
+    auto verify_pos = m_verify.begin();
+    auto verify_last = m_verify.end();
+    auto skip_pos = m_proof.m_skip.begin();
+    auto skip_last = m_proof.m_skip.end();
+
+    auto visitor = [&stack, &verify_pos, &verify_last, &skip_pos, &skip_last](std::size_t depth, MerkleLink value, bool right) -> bool
+    {
+        const uint256* new_hash = nullptr;
+        switch (value) {
+            case MerkleLink::DESCEND:
+                stack.emplace_back();
+                return false;
+
+            case MerkleLink::VERIFY:
+                if (verify_pos == verify_last) // detect read past end of verify hashes list
+                    return true;
+                new_hash = &(verify_pos++)[0];
+                break;
+
+            case MerkleLink::SKIP:
+                if (skip_pos == skip_last) // detect read past end of skip hashes list
+                    return true;
+                new_hash = &(skip_pos++)[0];
+                break;
+        }
+
+        uint256 tmp;
+        while (stack.back().first) {
+            MerkleHash_Sha256Midstate(tmp, stack.back().second, *new_hash);
+            new_hash = &tmp;
+            stack.pop_back();
+        }
+
+        stack.back().first = true;
+        stack.back().second = *new_hash;
+        return false;
+    };
+
+    /* As a special case, an empty proof with no verify hashes results
+     * in the unsalted hash of empty string.  Although this requires
+     * extra work in this implementation to support, it provides
+     * continuous semantics to the meaning of the MERKLEBLOCKVERIFY
+     * opcode, which might potentially reduce the number of code paths
+     * in some scripts. */
+    if (m_proof.m_path.empty() && m_verify.empty() && m_proof.m_skip.empty()) {
+        if (invalid) {
+            *invalid = false;
+        }
+        return CHashWriter(SER_GETHASH, PROTOCOL_VERSION).GetHash();
+    }
+
+    /* Except for the special case of a 0-node, 0-verify, 0-skip tree,
+     * it is always the case (for any binary tree), that the number of
+     * leaf nodes (verify + skip) is one more than the number of
+     * internal nodes in the tree. */
+    if ((m_verify.size() + m_proof.m_skip.size()) != (m_proof.m_path.size() + 1)) {
+        if (invalid) {
+            *invalid = true;
+        }
+        return uint256();
+    }
+
+    /* If there are NO nodes in the tree, then this is the degenerate
+     * case of a single hash, in either the verify or skip set. */
+    if (m_proof.m_path.empty()) {
+        if (invalid) {
+            *invalid = false;
+        }
+        return m_verify.empty() ? m_proof.m_skip[0]
+                                : m_verify[0];
+    }
+
+    auto res = depth_first_traverse(m_proof.m_path.begin(), m_proof.m_path.end(), visitor);
+
+    if (res.first != m_proof.m_path.end() // m_proof.m_path has "extra" Nodes (after end of tree)
+        || res.second                     // m_proof.m_path has insufficient Nodes (tree not finished)
+        || stack.size() != 1              // expected one root hash...
+        || !stack.back().first)           // ...and an actual hash, not a placeholder
+    {
+        if (invalid)
+            *invalid = true;
+        return uint256();
+    }
+
+    if (invalid) {
+        *invalid = (verify_pos != verify_last // did not use all verify hashes
+                   || skip_pos != skip_last); // did not use all skip hashes
+    }
+
+    return stack.back().second;
+}
+
+// End of File

--- a/src/consensus/merkleproof.h
+++ b/src/consensus/merkleproof.h
@@ -1,0 +1,1415 @@
+// Copyright (c) 2017-2019 The Freicoin Developers
+//
+// This program is free software: you can redistribute it and/or
+// modify it under the conjunctive terms of BOTH version 3 of the GNU
+// Affero General Public License as published by the Free Software
+// Foundation AND the MIT/X11 software license.
+//
+// This program is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Affero General Public License and the MIT/X11 software license for
+// more details.
+//
+// You should have received a copy of both licenses along with this
+// program.  If not, see <https://www.gnu.org/licenses/> and
+// <http://www.opensource.org/licenses/mit-license.php>
+
+#ifndef BITCOIN_MERKLE_PROOF
+#define BITCOIN_MERKLE_PROOF
+
+#include <array>
+
+#include "serialize.h"
+#include "uint256.h"
+
+/*
+ * Each link of a Merkle tree can have one of three values in a proof
+ * object:
+ *
+ *   DESCEND: This link connects to another sub-tree, which must be
+ *     processed.  The root of this sub-tree is the hash value of the
+ *     link.
+ *
+ *   VERIFY: This hash value of this link must be provided at
+ *     validation time.  Computation of the Merkle root and comparison
+ *     with a reference value provides a batch confirmation as to
+ *     whether ALL the provided VERIFY hashes are correct.
+ *
+ *   SKIP: The hash value of this link is provided as part of the
+ *     proof.
+ */
+enum class MerkleLink : unsigned char { DESCEND, VERIFY, SKIP };
+
+/*
+ * An internal node of a proof can take on up to eight different
+ * forms, the product of the 3 possible MerkleLink states the left and
+ * right branches can each take, when the impossible {SKIP, SKIP}
+ * state is excluded (this hypothetical state would be pruned as a
+ * SKIP hash in the parent's node).  This means nodes can be encoded
+ * as a 3-bit integer, and packed 8 nodes to each 3 byte sequence.
+ *
+ * The MerkleNode class uses an unsigned char to represent the
+ * unpacked code, whereas the MerkleNodeReference class is used to
+ * access a 3-bit code value within this packed representation.
+ */
+struct MerkleNode
+{
+    typedef unsigned char code_type;
+
+protected:
+    code_type m_code;
+
+    /* Look-up tables to infer the value (DESCEND, VERIFY, or SKIP) of
+     * the left- and right-links. */
+    static const std::array<MerkleLink, 8> m_left_from_code;
+    static const std::array<MerkleLink, 8> m_right_from_code;
+
+    /* Helper method to calculate the internal encoding of a node. */
+    static code_type _encode(MerkleLink left, MerkleLink right);
+
+public:
+    MerkleNode(MerkleLink left, MerkleLink right) : m_code(_encode(left, right)) { }
+
+    /* Must be explicit to avoid unintentional integer or boolean
+     * promotion assignments.  See also the related note about
+     * GetCode() and SetCode() below. */
+    explicit MerkleNode(code_type code) : m_code(code) { }
+
+    /* Note that a code value of 0 is a {VERIFY, SKIP} node. */
+    MerkleNode() : m_code(0) { }
+
+    /* The default behavior is adequate. */
+    MerkleNode(const MerkleNode&) = default;
+    MerkleNode(MerkleNode&&) = default;
+    MerkleNode& operator=(const MerkleNode&) = default;
+    MerkleNode& operator=(MerkleNode&&) = default;
+
+    /* Ideally this would perhaps be operator int() and operator=(),
+     * however C++ does not let us mark an assingment operator as
+     * explicit.  This unfortunately defeats many of the protections
+     * against bugs that strong typing would give us as any integer or
+     * Boolean value could be mistakenly assigned and interpreted as a
+     * code, therefore assignable to a MerkleNode, and probably
+     * generating a memory access exception if the value is not
+     * between 0 and 7. */
+    inline code_type GetCode() const
+      { return m_code; }
+
+    inline MerkleNode& SetCode(code_type code)
+    {
+        m_code = code;
+        return *this;
+    }
+
+    /* The getters and setters for the left and right MerkleLinks
+     * simply recalculate the code value using tables.  The code
+     * values line up such that this could be done with arithmetic and
+     * shifts, but that would probably be one optimization too far in
+     * terms of clarity. */
+    inline MerkleLink GetLeft() const
+      { return m_left_from_code[m_code]; }
+
+    inline MerkleNode& SetLeft(MerkleLink left)
+    {
+        m_code = _encode(left, m_right_from_code[m_code]);
+        return *this;
+    }
+
+    inline MerkleLink GetRight() const
+      { return m_right_from_code[m_code]; }
+
+    inline MerkleNode& SetRight(MerkleLink right)
+    {
+        m_code = _encode(m_left_from_code[m_code], right);
+        return *this;
+    }
+
+    /* Equality operators. */
+    inline bool operator==(MerkleNode other) const
+      { return (m_code == other.m_code); }
+    inline bool operator!=(MerkleNode other) const
+      { return !(*this == other); }
+
+    /* Relational operators.
+     *
+     * At first glance this doesn't make sense to include except for
+     * obscure reasons such as STL container compatibility, however
+     * the encoding scheme was chosen to preserve list ordering
+     * relationships when differing proofs of the same underlying tree
+     * structure are compared. */
+    inline bool operator<(MerkleNode other) const
+      { return (m_code < other.m_code); }
+    inline bool operator<=(MerkleNode other) const
+      { return !(other < *this); }
+    inline bool operator>=(MerkleNode other) const
+      { return !(*this < other); }
+    inline bool operator>(MerkleNode other) const
+      { return (other < *this); }
+
+    /* Needs access to m_{left,right}_from_code and _encode() */
+    friend struct MerkleNodeReference;
+};
+
+/*
+ * Now we begin constructing the necessary infrastructure for
+ * supporting an STL-like container for packed 3-bit code
+ * representations of MerkleNode values.
+ *
+ * This is parallels the way that std::vector<bool> is specialized,
+ * but with the added complication of a non-power-of-2 packed size.
+ */
+
+/*
+ * First we build a "reference" class which is able to address the
+ * location of a packed 3-bit value, and to read and write that value
+ * without affecting its neighbors.
+ *
+ * Then we will make use of this MerkleNode reference type to
+ * construct an STL-compatible iterator class (technically two, since
+ * the container's const_iterator is not a const instance of the
+ * iterator, because "const" in this case refers to the underlying
+ * reference not the iterator itself).
+ */
+struct MerkleNodeReference
+{
+    /* Nodes are stored with a tightly packed 3-bit encoding, the
+     * code.  This allows up to 8 node specifications to fit within 3
+     * bytes:
+     *
+     *    -- Node index
+     *   /
+     *   00011122 23334445 55666777
+     *    byte 0   byte 1   byte 2
+     *   76543210 76543210 76543210
+     *                            /
+     *                Bit Index --
+     *
+     * A reference to a particular node consists of a pointer to the
+     * beginning of this 3 byte sequence, and the index (between 0 and
+     * 7) of the node referenced. */
+    typedef unsigned char base_type;
+    /* Alas, C++ does not offer a 3-bit integer type: */
+    typedef unsigned char offset_type;
+
+protected:
+    base_type* m_base;
+    offset_type m_offset;
+
+    /* The parameterized constructor is protected because MerkleNode
+     * references should only ever be created by the friended iterator
+     * and container code. */
+    MerkleNodeReference(base_type* base, offset_type offset) : m_base(base), m_offset(offset) { }
+
+    /* We're emulating a reference, not a pointer, and it doesn't make
+     * sense to have default-constructable references. */
+    MerkleNodeReference() = delete;
+
+public:
+    /* The default copy constructors are sufficient. Note that these
+     * create a new reference object that points to the same packed
+     * MerkleNode value. */
+    MerkleNodeReference(const MerkleNodeReference& other) = default;
+    MerkleNodeReference(MerkleNodeReference&& other) = default;
+
+    /* Copy assignment operators are NOT the default behavior:
+     * assigning one reference to another copies the underlying
+     * values, to make the MerkleNodeReference objects behave like
+     * references. It is NOT the same as the copy constructor, which
+     * copies the reference itself. */
+    inline MerkleNodeReference& operator=(const MerkleNodeReference& other)
+      { return SetCode(other.GetCode()); }
+    inline MerkleNodeReference& operator=(MerkleNodeReference&& other)
+      { return SetCode(other.GetCode()); }
+
+public:
+    /* Read a 3-bit code value */
+    MerkleNode::code_type GetCode() const;
+
+    /* Write a 3-bit code value */
+    MerkleNodeReference& SetCode(MerkleNode::code_type code);
+
+    /* Read and write the MerkleLink values individually. */
+    inline MerkleLink GetLeft() const
+      { return MerkleNode::m_left_from_code[GetCode()]; }
+    inline MerkleNodeReference& SetLeft(MerkleLink left)
+      { return SetCode(MerkleNode::_encode(left, GetRight())); }
+
+    inline MerkleLink GetRight() const
+      { return MerkleNode::m_right_from_code[GetCode()]; }
+    inline MerkleNodeReference& SetRight(MerkleLink right)
+      { return SetCode(MerkleNode::_encode(GetLeft(), right)); }
+
+    /* Equality operators. */
+    inline bool operator==(const MerkleNodeReference& other) const
+      { return (GetCode() == other.GetCode()); }
+    inline bool operator==(MerkleNode other) const
+      { return (GetCode() == other.GetCode()); }
+    inline bool operator!=(const MerkleNodeReference& other) const
+      { return (GetCode() != other.GetCode()); }
+    inline bool operator!=(MerkleNode other) const
+      { return (GetCode() != other.GetCode()); }
+
+    /* Relational operators. */
+    inline bool operator<(const MerkleNodeReference& other) const
+      { return (GetCode() < other.GetCode()); }
+    inline bool operator<(MerkleNode other) const
+      { return (GetCode() < other.GetCode()); }
+    inline bool operator<=(const MerkleNodeReference& other) const
+      { return (GetCode() <= other.GetCode()); }
+    inline bool operator<=(MerkleNode other) const
+      { return (GetCode() <= other.GetCode()); }
+    inline bool operator>=(const MerkleNodeReference& other) const
+      { return (GetCode() >= other.GetCode()); }
+    inline bool operator>=(MerkleNode other) const
+      { return (GetCode() >= other.GetCode()); }
+    inline bool operator>(const MerkleNodeReference& other) const
+      { return (GetCode() > other.GetCode()); }
+    inline bool operator>(MerkleNode other) const
+      { return (GetCode() > other.GetCode()); }
+
+    /* Conversion to/from class MerkleNode */
+    inline MerkleNodeReference& operator=(const MerkleNode& other)
+      { return SetCode(other.GetCode()); }
+    inline operator MerkleNode() const
+      { return MerkleNode(GetCode()); }
+
+protected:
+    /* Needs C(base,offset) and access to m_base and m_offset */
+    friend struct MerkleNodeIteratorBase;
+
+    /* Needs C(base,offset) */
+    template<class T, class Alloc> friend class std::vector;
+};
+
+/*
+ * Equality and relational operators that couldn't have been defined
+ * inside MerkleNode because MerkleNodeReference was not defined.
+ */
+inline bool operator==(MerkleNode lhs, const MerkleNodeReference& rhs)
+  { return (lhs.GetCode() == rhs.GetCode()); }
+inline bool operator!=(MerkleNode lhs, const MerkleNodeReference& rhs)
+  { return (lhs.GetCode() != rhs.GetCode()); }
+inline bool operator<(MerkleNode lhs, const MerkleNodeReference& rhs)
+  { return (lhs.GetCode() < rhs.GetCode()); }
+inline bool operator<=(MerkleNode lhs, const MerkleNodeReference& rhs)
+  { return (lhs.GetCode() <= rhs.GetCode()); }
+inline bool operator>=(MerkleNode lhs, const MerkleNodeReference& rhs)
+  { return (lhs.GetCode() >= rhs.GetCode()); }
+inline bool operator>(MerkleNode lhs, const MerkleNodeReference& rhs)
+  { return (lhs.GetCode() > rhs.GetCode()); }
+
+/*
+ * Now we construct an STL-compatible iterator object. If you are not
+ * familiar with writing STL iterators, this might be difficult to
+ * review.  In-line commentary explaining general facets of iterator
+ * implementation would be too verbose, so I encourage reviewers to
+ * compare this with their own standard library's implementation of
+ * std::vector<bool>'s iterators as well as available documentation
+ * for std::iterator, as necessary.
+ *
+ * We derive from std::iterator basically just to provide the ability
+ * specialize algorithms based on iterator category tags.  All iterator
+ * functionality must be re-implemented by this class due to the
+ * peculiarities of iterating over packed representations.
+ *
+ * Note, if you're not aware, that for STL containers const_iterator
+ * is not the iterator class with a const qualifier applied.  The
+ * const in the typename refers the references it generates; a
+ * const_iterator itself is mutable, otherwise you wouldn't be able to
+ * advance it.  The class MerkleNodeIteratorBase implements the common
+ * functionality and the two iterator classes derive from it.
+ */
+struct MerkleNodeIteratorBase : public std::iterator<std::random_access_iterator_tag,
+                                                     MerkleNodeReference::base_type>
+{
+    /* The value extracted from an iterator is a MerkleNode, or more
+     * properly a MerkleNodeReference (iterator) or const MerkleNode
+     * (const_iterator). The packed array of 3-bit code values only
+     * has its values extracted and then converted to MerkleNode as
+     * necessary on the fly. */
+    typedef MerkleNode value_type;
+    typedef std::ptrdiff_t difference_type;
+
+protected:
+    MerkleNodeReference m_ref;
+
+    /* A pass through initializer used by the derived iterator types,
+     * since otherwise m_ref would not be accessible to their
+     * constructor member initialization lists. */
+    MerkleNodeIteratorBase(MerkleNodeReference::base_type* base, MerkleNodeReference::offset_type offset) : m_ref(base, offset) { }
+
+    /* Constructing an iterator from another iterator clones the
+     * underlying reference. */
+    MerkleNodeIteratorBase(const MerkleNodeIteratorBase&) = default;
+    MerkleNodeIteratorBase(MerkleNodeIteratorBase&&) = default;
+
+    /* Copy assignment clones the underlying reference, but using the
+     * default copy assignment operator would not work since it calls
+     * the underlying MerkleNodeReference structure's custom copy
+     * assignment operator, which emulates reference assignment
+     * (destructive) instead of cloning the reference itself.  In this
+     * context we want is what would otherwise be the default
+     * behavior--cloning the reference--which we must implement
+     * ourselves. */
+    inline MerkleNodeIteratorBase& operator=(const MerkleNodeIteratorBase& other)
+    {
+        m_ref.m_base = other.m_ref.m_base;
+        m_ref.m_offset = other.m_ref.m_offset;
+        return *this;
+    }
+
+    inline MerkleNodeIteratorBase& operator=(MerkleNodeIteratorBase&& other)
+    {
+        m_ref.m_base = other.m_ref.m_base;
+        m_ref.m_offset = other.m_ref.m_offset;
+        return *this;
+    }
+
+public:
+    /* Distance: the number of increments required to get from *this
+     * to other. */
+    difference_type operator-(const MerkleNodeIteratorBase& other) const;
+
+    /*
+     * The standard increment, decrement, advancement, etc. operators
+     * for both iterator and const_iterator have the same internal
+     * implementation and could be defined here, but then they would
+     * be returning instances of the base class not the iterator. So
+     * look to those definitions in the derived classes below.
+     */
+
+    /* Equality operators.
+     *
+     * Note: Comparing the underlying reference directly with
+     *       MerkleNodeReference::operator== and friends would result
+     *       in the underlying values being compared, not the memory
+     *       addresses. */
+    inline bool operator==(const MerkleNodeIteratorBase& other) const
+    {
+        return m_ref.m_base == other.m_ref.m_base
+            && m_ref.m_offset == other.m_ref.m_offset;
+    }
+
+    inline bool operator!=(const MerkleNodeIteratorBase& other) const
+      { return !(*this == other); }
+
+    /* Relational operators. */
+    inline bool operator<(const MerkleNodeIteratorBase& other) const
+    {
+        return m_ref.m_base < other.m_ref.m_base
+           || (m_ref.m_base == other.m_ref.m_base && m_ref.m_offset < other.m_ref.m_offset);
+    }
+
+    inline bool operator<=(const MerkleNodeIteratorBase& other) const
+      { return !(other < *this); }
+    inline bool operator>=(const MerkleNodeIteratorBase& other) const
+      { return !(*this < other); }
+    inline bool operator>(const MerkleNodeIteratorBase& other) const
+      { return other < *this; }
+
+protected:
+    /* Move to the next 3-bit code value, incrementing m_base (by 3)
+     * if we've gone past the end of a 3-byte block of 8 code values
+     * it points to. */
+    void _incr();
+
+    /* Move to the prior 3-bit code value, moving m_back back (by 3)
+     * if we've gone past the beginning of the 3-byte block of 8 code
+     * values it points to. */
+    void _decr();
+
+    /* Move an arbitrary number of elements forward or backwards.
+     * Used to implement random access interface with constant time
+     * properties (see related operator-() definition below). */
+    void _seek(difference_type distance);
+};
+
+/*
+ * Forward random access iterator, using the _incr(), _decr(), _seek()
+ * and operator-() methods of MerkleNodeIteratorBase, which is the
+ * important business logic. This class is mostly just API wrappers to
+ * provide an API interface close enough to API compatible with STL
+ * iterators to be usable with other standard library generics.
+ */
+struct MerkleNodeIterator : public MerkleNodeIteratorBase
+{
+    typedef MerkleNodeIterator iterator;
+    typedef MerkleNodeReference reference;
+    typedef MerkleNodeReference* pointer;
+
+    /* Default constructor makes an unsafe iterator that will crash if
+     * dereferenced, but is required so that an iterator variable can
+     * declared and initialized separately--a common usage pattern. */
+    MerkleNodeIterator() : MerkleNodeIteratorBase(nullptr, 0) { }
+
+    /* Default copy/move constructors and assignment operators are fine. */
+    MerkleNodeIterator(const MerkleNodeIterator& other) = default;
+    MerkleNodeIterator(MerkleNodeIterator&& other) = default;
+    MerkleNodeIterator& operator=(const MerkleNodeIterator& other) = default;
+    MerkleNodeIterator& operator=(MerkleNodeIterator&& other) = default;
+
+protected:
+    MerkleNodeIterator(MerkleNodeReference::base_type* base,
+                       MerkleNodeReference::offset_type offset)
+        : MerkleNodeIteratorBase(base, offset) { }
+
+public:
+    /* Dereference interface. */
+    inline reference operator*() const
+      { return m_ref; }
+    inline pointer operator->() const
+      { return const_cast<pointer>(&m_ref); }
+
+    /* Bidirectional interface. */
+    inline iterator& operator++()
+    {
+        _incr();
+        return *this;
+    }
+
+    inline iterator operator++(int)
+    {
+        iterator ret(*this);
+        _incr();
+        return ret;
+    }
+
+    inline iterator& operator--()
+    {
+        _decr();
+        return *this;
+    }
+
+    inline iterator operator--(int)
+    {
+        iterator ret(*this);
+        _decr();
+        return ret;
+    }
+
+    /* Random access interface. */
+    inline difference_type operator-(const MerkleNodeIterator& other) const
+    {
+        /* The base class implements this correctly, but since we
+         * define another overload of operator-() below, we need to
+         * explicitly implement this variant too. */
+        return MerkleNodeIteratorBase::operator-(other);
+    }
+
+    inline iterator& operator+=(difference_type n)
+    {
+        _seek(n);
+        return *this;
+    }
+
+    inline iterator& operator-=(difference_type n)
+    {
+        _seek(-n);
+        return *this;
+    }
+
+    inline iterator operator+(difference_type n) const
+    {
+        iterator ret(*this);
+        ret._seek(n);
+        return ret;
+    }
+
+    inline iterator operator-(difference_type n) const
+    {
+        iterator ret(*this);
+        ret._seek(-n);
+        return ret;
+    }
+
+    inline reference operator[](difference_type n) const
+      { return *(*this + n); }
+
+protected:
+    /* std::vector<Node> specialization uses C(base,offset) */
+    template<class T, class Alloc> friend class std::vector;
+};
+
+inline MerkleNodeIterator operator+(MerkleNodeIterator::difference_type n, const MerkleNodeIterator& x)
+  { return x + n; }
+
+/*
+ * An iterator that returns const references.  Not that this is
+ * semantically different from a `const MerkleNodeIterator`.
+ */
+struct MerkleNodeConstIterator : public MerkleNodeIteratorBase
+{
+    typedef MerkleNodeConstIterator iterator;
+    typedef const MerkleNodeReference reference;
+    typedef const MerkleNodeReference* pointer;
+
+    /* Creates an unsafe iterator with a sentinal value, which will
+     * crash if dereferenced.  Required to support the common code
+     * pattern of separating variable definitions from
+     * initialization. */
+    MerkleNodeConstIterator() : MerkleNodeIteratorBase(nullptr, 0) { }
+
+    /* Pass-through constructor of the m_ref field. */
+    MerkleNodeConstIterator(const MerkleNodeIterator& other)
+        : MerkleNodeIteratorBase(static_cast<const MerkleNodeIteratorBase&>(other)) { }
+
+    /* Default copy/move constructors and assignment operators are fine. */
+    MerkleNodeConstIterator(const MerkleNodeConstIterator& other) = default;
+    MerkleNodeConstIterator(MerkleNodeConstIterator&& other) = default;
+    MerkleNodeConstIterator& operator=(const MerkleNodeConstIterator& other) = default;
+    MerkleNodeConstIterator& operator=(MerkleNodeConstIterator&& other) = default;
+
+protected:
+    /* const_cast is required (and allowed) because the const
+     * qualifier is only dropped to copy its value into m_ref.  No API
+     * is provided to actually manipulate the underlying value of the
+     * reference by this class. */
+    MerkleNodeConstIterator(const MerkleNodeReference::base_type* base,
+                            MerkleNodeReference::offset_type offset)
+        : MerkleNodeIteratorBase(const_cast<MerkleNodeReference::base_type*>(base), offset) { }
+
+public:
+    /* Dereference interface. */
+    inline reference operator*() const
+      { return m_ref; }
+    inline pointer operator->() const
+      { return &m_ref; }
+
+    /* Bidirectional interface. */
+    inline iterator& operator++()
+    {
+        _incr();
+        return *this;
+    }
+
+    inline iterator operator++(int)
+    {
+        iterator tmp = *this;
+        _incr();
+        return tmp;
+    }
+
+    inline iterator& operator--()
+    {
+        _decr();
+        return *this;
+    }
+
+    inline iterator operator--(int)
+    {
+        iterator tmp = *this;
+        _decr();
+        return tmp;
+    }
+
+    /* Random access interface. */
+    inline difference_type operator-(const MerkleNodeConstIterator& other) const
+    {
+        /* The base class implements this correctly, but since we define
+         * another version of operator-() below, we need to explicitly
+         * implement this variant too. */
+        return MerkleNodeIteratorBase::operator-(other);
+    }
+
+    inline iterator& operator+=(difference_type n)
+    {
+        _seek(n);
+        return *this;
+    }
+
+    inline iterator& operator-=(difference_type n)
+    {
+        *this += -n;
+        return *this;
+    }
+
+    inline iterator operator+(difference_type n) const
+    {
+        iterator tmp = *this;
+        return tmp += n;
+    }
+
+    inline iterator operator-(difference_type n) const
+    {
+        iterator tmp = *this;
+        return tmp -= n;
+    }
+
+    inline reference operator[](difference_type n) const
+      { return *(*this + n); }
+
+protected:
+    /* std::vector<MerkleNode> uses C(base,offset) */
+    template<class T, class Alloc> friend class std::vector;
+};
+
+inline MerkleNodeConstIterator operator+(MerkleNodeConstIterator::difference_type n, const MerkleNodeConstIterator& x)
+  { return x + n; }
+
+/*
+ * Now we are ready to define the specialization of std::vector for
+ * packed 3-bit MerkleNode values.  We use a std::vector<unsigned char>
+ * as the underlying container to hold the encoded bytes, with 3
+ * packed MerkleNodes per byte.  We then provide a std::vector
+ * compatible API to return iterators over MerkleNodeReference objects
+ * inside this packed array.
+ */
+namespace std {
+template<class Allocator>
+class vector<MerkleNode, Allocator>
+{
+public:
+    typedef MerkleNode value_type;
+    /* Resolves to (unsigned char*): */
+    typedef MerkleNodeReference::base_type base_type;
+    /* Standard allocator idiom: */
+    typedef typename Allocator::template rebind<value_type>::other allocator_type;
+    /* Use std platform-defined pointer info types: */
+    typedef std::size_t size_type;
+    typedef std::ptrdiff_t difference_type;
+    /* Custom iterator implementations: */
+    typedef MerkleNodeIterator iterator;
+    typedef MerkleNodeConstIterator const_iterator;
+    typedef std::reverse_iterator<iterator> reverse_iterator;
+    typedef std::reverse_iterator<const_iterator> const_reverse_iterator;
+    /* Reuse definitions from iterators: */
+    typedef iterator::reference reference;
+    typedef const_iterator::reference const_reference;
+    typedef iterator::pointer pointer;
+    typedef const_iterator::pointer const_pointer;
+
+protected:
+    /* A std::vector<unsignd char> is what is actually used to store
+     * the packed Node representation. */
+    typedef typename Allocator::template rebind<base_type>::other base_allocator_type;
+    typedef std::vector<base_type, base_allocator_type> vch_type;
+
+    /* m_vch.size() is (3 * m_count) / 8, but because of the truncation
+     * we can't know from m_vch.size() alone how many nodes are in the
+     * tree structure, so the count needs to be stored explicitly. */
+    vch_type m_vch;
+    size_type m_count;
+
+    /* Returns the required size of m_vch to contain count packed Nodes. */
+    static inline const typename vch_type::size_type _vch_size(size_type count)
+      { return (3 * count + 7) / 8; }
+
+public:
+    explicit vector(const Allocator& alloc = Allocator())
+        : m_vch(static_cast<base_allocator_type>(alloc)), m_count(0) { }
+
+    /* Yes, this doesn't allow specifying the allocator.  That is a
+     * bug in C++11, fixed in C++14.  However we aim for exact
+     * compatibility with the version of C++ used by Bitcoin Core,
+     * which is still pegged to C++11.
+     *
+     * Note: Because m_vch is a vector of a primitive type, its values
+     *       are value initialized to zero according to the C++11
+     *       standard.  We don't need to do anything.  Note, however,
+     *       that in prior versions of the standard the behavior was
+     *       different and this implementation will not work with
+     *       pre-C++11 compilers. */
+    explicit vector(size_type count)
+        : m_vch(_vch_size(count)), m_count(count) { }
+
+    vector(size_type count, value_type value, const Allocator& alloc = Allocator())
+        : m_vch(_vch_size(count), 0, static_cast<base_allocator_type>(alloc)), m_count(count)
+    {
+        MerkleNode::code_type code = value.GetCode();
+        if (code) // Already filled with zeros
+            _fill(0, count, code);
+    }
+
+    /* Assign constructors. */
+    template<class InputIt>
+    vector(InputIt first, InputIt last, const Allocator& alloc = Allocator())
+        : m_vch(static_cast<base_allocator_type>(alloc)), m_count(0)
+    {
+        insert(begin(), first, last);
+    }
+
+    vector(std::initializer_list<value_type> ilist, const Allocator& alloc = Allocator())
+        : m_vch(static_cast<base_allocator_type>(alloc)), m_count(0)
+    {
+        assign(ilist);
+    }
+
+    /* Copy constructors. */
+    vector(const vector& other) = default;
+    vector(const vector& other, const Allocator& alloc)
+        : m_vch(other.m_vch, static_cast<base_allocator_type>(alloc)), m_count(other.m_count) { }
+    vector(vector&& other) = default;
+    vector(vector&& other, const Allocator& alloc)
+        : m_vch(other.m_vch, static_cast<base_allocator_type>(alloc)), m_count(other.m_count) { }
+
+    /* Assignment operators. */
+    vector& operator=(const vector& other) = default;
+    vector& operator=(vector&& other) = default;
+
+    inline vector& operator=(std::initializer_list<value_type> ilist)
+    {
+        assign(ilist);
+        return *this;
+    }
+
+    /* Equality operators. */
+    inline bool operator==(const vector &other) const
+      { return ((m_count == other.m_count) && (m_vch == other.m_vch)); }
+    inline bool operator!=(const vector &other) const
+      { return !(*this == other); }
+
+    /* Relational operators. */
+    inline bool operator<(const vector &other) const
+      { return ((m_vch < other.m_vch) || ((m_vch == other.m_vch) && (m_count < other.m_count))); }
+    inline bool operator<=(const vector &other) const
+      { return !(other < *this); }
+    inline bool operator>=(const vector &other) const
+      { return !(*this < other); }
+    inline bool operator>(const vector &other) const
+      { return (other < *this); }
+
+    /* Clear & assign methods. */
+    void clear() noexcept
+    {
+        m_vch.clear();
+        m_count = 0;
+    }
+
+    void assign(size_type count, value_type value)
+    {
+        clear();
+        insert(begin(), count, value);
+    }
+
+    template<class InputIt>
+    void assign(InputIt first, InputIt last)
+    {
+        clear();
+        insert(begin(), first, last);
+    }
+
+    void assign(std::initializer_list<value_type> ilist)
+    {
+        clear();
+        reserve(ilist.size());
+        for (auto node : ilist)
+            push_back(node);
+    }
+
+    allocator_type get_allocator() const
+      { return allocator_type(m_vch.get_allocator()); }
+
+    /* Item access: */
+    reference at(size_type pos)
+    {
+        if (!(pos < size()))
+            throw std::out_of_range("vector<Node>::at out of range");
+        return (*this)[pos];
+    }
+
+    const_reference at(size_type pos) const
+    {
+        if (!(pos < size()))
+            throw std::out_of_range("vector<Node>::at out of range");
+        return (*this)[pos];
+    }
+
+    inline reference operator[](size_type pos)
+      { return reference(data() + (3 * (pos / 8)), pos % 8); }
+    inline const_reference operator[](size_type pos) const
+      { return const_reference(const_cast<const_reference::base_type*>(data() + (3 * (pos / 8))), pos % 8); }
+
+    inline reference front()
+      { return (*this)[0]; }
+    inline const_reference front() const
+      { return (*this)[0]; }
+
+    inline reference back()
+      { return (*this)[m_count-1]; }
+    inline const_reference back() const
+      { return (*this)[m_count-1]; }
+
+    inline base_type* data()
+      { return m_vch.data(); }
+    inline const base_type* data() const
+      { return m_vch.data(); }
+
+    /* Iterators: */
+    inline iterator begin() noexcept
+      { return iterator(data(), 0); }
+    inline const_iterator begin() const noexcept
+      { return const_iterator(data(), 0); }
+    inline const_iterator cbegin() const noexcept
+      { return begin(); }
+
+    inline iterator end() noexcept
+      { return iterator(data() + (3 * (m_count / 8)), m_count % 8); }
+    inline const_iterator end() const noexcept
+      { return const_iterator(data() + (3 * (m_count / 8)), m_count % 8); }
+    inline const_iterator cend() const noexcept
+      { return end(); }
+
+    inline reverse_iterator rbegin() noexcept
+      { return reverse_iterator(end()); }
+    inline const_reverse_iterator rbegin() const noexcept
+      { return const_reverse_iterator(end()); }
+    inline const_reverse_iterator crbegin() const noexcept
+      { return rbegin(); }
+
+    inline reverse_iterator rend() noexcept
+      { return reverse_iterator(begin()); }
+    inline const_reverse_iterator rend() const noexcept
+      { return const_reverse_iterator(begin()); }
+    inline const_reverse_iterator crend() const noexcept
+      { return rend(); }
+
+    /* Size and capacity: */
+    inline bool empty() const noexcept
+      { return !m_count; }
+
+    inline size_type size() const noexcept
+      { return m_count; }
+
+    inline size_type max_size() const noexcept
+    {
+        /* We must be careful in what we return due to overflow. */
+        return std::max(m_vch.max_size(), 8 * m_vch.max_size() / 3);
+    }
+
+    inline void reserve(size_type new_cap)
+      { m_vch.reserve(_vch_size(new_cap)); }
+
+    inline size_type capacity() const noexcept
+    {
+        /* Again, careful of overflow, although it is more of a
+         * theoretical concern here since such limitations would only
+         * be encountered if the vector consumed more than 1/8th of
+         * the addressable memory range. */
+        return std::max(m_count, 8 * m_vch.capacity() / 3);
+    }
+
+    inline void resize(size_type count)
+      { resize(count, value_type()); }
+
+    void resize(size_type count, value_type value)
+    {
+        auto old_count = m_count;
+        _resize(count);
+        if (old_count < count)
+            _fill(old_count, count, value.GetCode());
+    }
+
+    inline void shrink_to_fit()
+      { m_vch.shrink_to_fit(); }
+
+protected:
+    /* Resizes the underlying vector to support the number of packed
+     * Nodes specified.  Does NOT initialize any newly allocated
+     * bytes, except for the unused bits in the last byte when
+     * shrinking or the last new byte added, to prevent acquisition of
+     * dirty status.  It is the responsibility of the caller to
+     * initialize any added new MerkleNodes. */
+    void _resize(size_type count)
+    {
+        if (count < m_count) {
+            /* Clear bits of elements being removed in the new last
+             * byte, for the purpose of not introducing dirty
+             * status. */
+            _fill(count, std::min((count + 7) & ~7, m_count), 0);
+        }
+        size_type new_vch_size = _vch_size(count);
+        m_vch.resize(new_vch_size);
+        if (m_count < count) {
+            /* Clear the last byte, if a byte is being added, so that
+             * none of the extra bits introduce dirty status. */
+            if (new_vch_size > _vch_size(m_count)) {
+                m_vch.back() = 0;
+            }
+        }
+        m_count = count;
+    }
+
+    /* A memmove()-like behavior over the packed elements of this
+     * container.  The source and the destination are allowed to
+     * overlap.  Any non-overlap in the source is left with its prior
+     * value intact. */
+    void _move(size_type first, size_type last, size_type dest)
+    {
+        /* TODO: This could be made much faster by copying chunks at a
+         *       time.  This far less efficient approach is taken
+         *       because it is more obviously correct and _move is not
+         *       in the pipeline critical to validation performance. */
+        if (dest < first) {
+            std::copy(begin()+first, begin()+last, begin()+dest);
+        }
+        if (first < dest) {
+            dest += last - first;
+            std::copy_backward(begin()+first, begin()+last, begin()+dest);
+        }
+    }
+
+    /* A std::fill()-like behavior over a range of the packed elements
+     * of this container. */
+    void _fill(size_type first, size_type last, MerkleNode::code_type value)
+    {
+        /* TODO: This could be made much faster for long ranges by
+         *       precomputing the 3-byte repeating sequence and using
+         *       that for long runs.  However this method mostly
+         *       exists for API compatability with std::vector, and is
+         *       not used by Merkle tree manipulation code, which at
+         *       best very infrequently needs to fill a range of
+         *       serialized MerkleNode code values. */
+        std::fill(begin()+first, begin()+last, MerkleNode(value));
+    }
+
+public:
+    iterator insert(const_iterator pos, value_type value)
+    {
+        difference_type n = pos - cbegin();
+        _resize(m_count + 1);
+        _move(n, m_count-1, n+1);
+        operator[](n) = value;
+        return (begin() + n);
+    }
+
+    iterator insert(const_iterator pos, size_type count, value_type value)
+    {
+        difference_type n = pos - cbegin();
+        _resize(m_count + count);
+        _move(n, m_count-count, n+count);
+        _fill(n, n+count, value.GetCode());
+        return (begin() + n);
+    }
+
+    /* TODO: This implementation should be correct.  It's a rather
+     *       trivial method to implement.  However (1) the lack of
+     *       easy non-interactive input iterators in the standard
+     *       library makes this difficult to write tests for; and (2)
+     *       it's not currently used anyway.  Still, for exact
+     *       compatibility with the standard container interface this
+     *       should get tested and implemented. */
+    template<class InputIt>
+    iterator insert(const_iterator pos, InputIt first, InputIt last, std::input_iterator_tag)
+    {
+        difference_type n = pos - cbegin();
+        for (; first != last; ++first, ++pos)
+            pos = insert(pos, *first);
+        return (begin() + n);
+    }
+
+    template<class InputIt>
+    iterator insert(const_iterator pos, InputIt first, InputIt last, std::forward_iterator_tag)
+    {
+        auto n = std::distance(cbegin(), pos);
+        auto len = std::distance(first, last);
+        _resize(m_count + len);
+        _move(n, m_count-len, n+len);
+        auto pos2 = begin() + n;
+        for (; first != last; ++first, ++pos2)
+            *pos2 = *first;
+        return (begin() + n);
+    }
+
+    template<class InputIt>
+    inline iterator insert(const_iterator pos, InputIt first, InputIt last)
+    {
+        /* Use iterator tag dispatching to be able to pre-allocate the
+         * space when InputIt is a random access iterator, to prevent
+         * multiple resizings on a large insert. */
+        return insert(pos, first, last, typename iterator_traits<InputIt>::iterator_category());
+    }
+
+    inline iterator insert(const_iterator pos, std::initializer_list<value_type> ilist)
+      { return insert(pos, ilist.begin(), ilist.end()); }
+
+    template<class... Args>
+    iterator emplace(const_iterator pos, Args&&... args)
+    {
+        difference_type n = pos - cbegin();
+        _resize(m_count + 1);
+        _move(n, m_count-1, n+1);
+        auto ret = begin() + n;
+        *ret = MerkleNode(args...);
+        return ret;
+    }
+
+    iterator erase(const_iterator pos)
+    {
+        difference_type n = pos - cbegin();
+        _move(n+1, m_count, n);
+        _resize(m_count - 1);
+        return (begin() + n);
+    }
+
+    iterator erase(const_iterator first, const_iterator last)
+    {
+        auto n = std::distance(cbegin(), first);
+        auto len = std::distance(first, last);
+        _move(n+len, m_count, n);
+        _resize(m_count - len);
+        return (begin() + n);
+    }
+
+    void push_back(value_type value)
+    {
+        if (m_vch.size() < _vch_size(m_count+1))
+            m_vch.push_back(0);
+        (*this)[m_count++] = value;
+    }
+
+    template<class... Args>
+    void emplace_back(Args&&... args)
+    {
+        if (m_vch.size() < _vch_size(m_count+1))
+            m_vch.push_back(0);
+        (*this)[m_count++] = MerkleNode(args...);
+    }
+
+    void pop_back()
+    {
+        (*this)[m_count-1].SetCode(0);
+        if (_vch_size(m_count-1) < m_vch.size())
+            m_vch.pop_back();
+        --m_count;
+    }
+
+    void swap(vector& other)
+    {
+        m_vch.swap(other.m_vch);
+        std::swap(m_count, other.m_count);
+    }
+
+public:
+    base_type dirty() const
+    {
+        switch (m_count%8) {
+            case 0:  return 0;
+            case 1:  return m_vch.back() & 0x1f;
+            case 2:  return m_vch.back() & 0x03;
+            case 3:  return m_vch.back() & 0x7f;
+            case 4:  return m_vch.back() & 0x0f;
+            case 5:  return m_vch.back() & 0x01;
+            case 6:  return m_vch.back() & 0x3f;
+            default: return m_vch.back() & 0x07;
+        }
+    }
+
+    ADD_SERIALIZE_METHODS;
+
+    template <typename Stream, typename Operation>
+    inline void SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
+        /* The size of the node array is prefixed by the number of
+         * nodes, not the number of bytes which much then be
+         * read. _resize() handles conversion between the two. */
+        uint64_t count = m_count;
+        READWRITE(VARINT(count));
+        if (ser_action.ForRead())
+            _resize(static_cast<size_type>(count));
+        /* The size of the underlying storage vector is always kept
+         * exactly equal to the minimum number of bytes necessary to
+         * store the number 3-bit packed code values, so we can just
+         * read and write it as a plain old data. */
+        if (!m_vch.empty()) {
+            READWRITE(REF(CFlatData(m_vch)));
+        }
+    }
+};
+
+/* Equality operators: */
+template<class A> inline bool operator==(const vector<MerkleNode, A> &lhs, const vector<MerkleNode, A> &rhs)
+  { return lhs.operator==(rhs); }
+template<class A> inline bool operator!=(const vector<MerkleNode, A> &lhs, const vector<MerkleNode, A> &rhs)
+  { return lhs.operator!=(rhs); }
+
+/* Relational operators: */
+template<class A> inline bool operator<(const vector<MerkleNode, A> &lhs, const vector<MerkleNode, A> &rhs)
+  { return lhs.operator<(rhs); }
+template<class A> inline bool operator<=(const vector<MerkleNode, A> &lhs, const vector<MerkleNode, A> &rhs)
+  { return lhs.operator<=(rhs); }
+template<class A> inline bool operator>=(const vector<MerkleNode, A> &lhs, const vector<MerkleNode, A> &rhs)
+  { return lhs.operator>=(rhs); }
+template<class A> inline bool operator>(const vector<MerkleNode, A> &lhs, const vector<MerkleNode, A> &rhs)
+  { return lhs.operator>(rhs); }
+} // namespace std
+
+/*
+ * We have implemented our own specialized serialization methods for
+ * std::vector<MerkleNode>.  However because the serialization API
+ * does not uses argument-dependent lookup, the generic std::vector
+ * serialization routines would get selected instead.  To make sure
+ * this doesn't happen, we specialize those templates to call
+ * std::vector<MerkleNode>::Serialize and Unserialize.
+ */
+template<typename Stream, typename T, typename A>
+void Serialize_impl(Stream& os, const std::vector<T, A>& v, int nType, int nVersion, const MerkleNode&)
+{
+    v.Serialize(os, nType, nVersion);
+}
+
+template<typename Stream, typename T, typename A>
+void Unserialize_impl(Stream& is, std::vector<T, A>& v, int nType, int nVersion, const MerkleNode&)
+{
+    v.Unserialize(is, nType, nVersion);
+}
+
+/*
+ * Tree traversal helper routines.
+ *
+ * Havig defined the std::vector<MerkleNode> representation of the
+ * structure of a Merkle tree, we define a helper routine to apply the
+ * visitor idiom in a depth-first traversal of a Merkle tree, which is
+ * the general strategy we will take towards working with Merkle
+ * trees.
+ */
+
+/*
+ * TraversalPredicate (used below) is a template parameter for a
+ * callable object or function pointer which supports the following
+ * API:
+ *
+ *   bool operator()(std::vector<Node>::size_t depth, MerkleLink value, bool is_right)
+ *
+ * It is called by the traversal routines both to process the contents
+ * of the tree (for example, calculate the Merkle root), or report
+ * reaching the end of traversal.
+ *
+ * size_t depth
+ *
+ *   The depth of the MerkleLink being processed. MerkleLinks of the
+ *   root node have a depth of 1.  Depth 0 would be the depth of a
+ *   single-hash tree, which has no internal nodes.
+ *
+ * MerkleLink value
+ *
+ *   The value of the link, one of MerkleLink::DESCEND,
+ *   MerkleLink::VERIFY, or MerkleLink::SKIP.
+ *
+ * bool is_right
+ *
+ *   false if this is a left-link, true if this is a right-link.
+ *
+ * returns bool
+ *
+ *   false if traversal should continue.  true causes traversal to
+ *   terminate and an iterator to the node containing the link in
+ *   question to be returned to the caller.
+ */
+
+/*
+ * Does a depth-first traversal of a tree.
+ *
+ * Starting with the root node first, the left link is passed to pred
+ * then advanced, and if it is MerkleLink::DESCEND then its sub-tree
+ * is recursively processed, then the right link followed by its
+ * sub-tree.  Traversal ends the first time any of following
+ * conditions hold true:
+ *
+ *   1. first == last;
+ *   2. the entire sub-tree with first as the root node has been
+ *      processed; or
+ *   3. pred() returns true.
+ *
+ * Iter first
+ *
+ *   The root of the subtree to be processed.
+ *
+ * Iter last
+ *
+ *   One past the last node to possibly be processed.  Traversal will
+ *   end earlier if it reaches the end of the subtree, or if
+ *   TraversalPredicate returns true.
+ *
+ * TraversalPredicate pred
+ *
+ *   A callable object or function pointer that executed for each link
+ *   in the tree.  It is passed the current depth, the MerkleLink
+ *   value, and a Boolean value indicating whether it is the left or
+ *   the right link.
+ *
+ * returns std::pair<Iter, bool>
+ *
+ *   Returns the iterator pointing to the node where traversal
+ *   terminated, and a Boolean value indicating whether it was the
+ *   left (false) or right (true) branch that triggered termination,
+ *   or {last, incomplete} if termination is due to hitting the end of
+ *   the range, where incomplete is a Boolean value indicating whether
+ *   termination was due to finishing the subtree (false) or merely
+ *   hitting the end of the range (true).
+ */
+template<class Iter, class TraversalPredicate>
+std::pair<Iter, bool> depth_first_traverse(Iter first, Iter last, TraversalPredicate pred)
+{
+    /* Depth-first traversal uses space linear with respect to the
+     * depth of the tree, which is logarithmetic in the case of a
+     * balanced tree.  What is stored is a path from the root to the
+     * node under consideration, and a record of whether it was the
+     * left (false) or right (true) branch that was taken. */
+    std::vector<std::pair<Iter, bool> > stack;
+
+    for (auto pos = first; pos != last; ++pos) {
+        /* Each branch is processed the same.  First we check if the
+         * branch meets the user-provided termination criteria.  Then
+         * if it is a MerkleLink::DESCEND we save our position on the
+         * stack and "recurse" down the link into the next layer. */
+        if (pred(stack.size()+1, pos->GetLeft(), false)) {
+            return {pos, false};
+        }
+        if (pos->GetLeft() == MerkleLink::DESCEND) {
+            stack.emplace_back(pos, false);
+            continue;
+        }
+
+        /* If the left link was MerkleLink::VERIFY or
+         * MerkleLink::SKIP, we continue on to the right branch in the
+         * same way. */
+        if (pred(stack.size()+1, pos->GetRight(), true)) {
+            return {pos, true};
+        }
+        if (pos->GetRight() == MerkleLink::DESCEND) {
+            stack.emplace_back(pos, true);
+            continue;
+        }
+
+        /* After processing a leaf node (neither left nor right
+         * branches are MerkleLink:DESCEND) we move up the path,
+         * processing the right branches of nodes for which we had
+         * descended the left-branch. */
+        bool done = false;
+        while (!stack.empty() && !done) {
+            if (stack.back().second) {
+                stack.pop_back();
+            } else {
+                if (pred(stack.size(), stack.back().first->GetRight(), true)) {
+                    return {stack.back().first, true};
+                }
+                stack.back().second = true;
+                if (stack.back().first->GetRight() == MerkleLink::DESCEND) {
+                    done = true;
+                }
+            }
+        }
+
+        /* We get to this point only after retreating up the path and
+         * hitting an inner node for which the right branch has not
+         * been explored (in which case the stack is not empty and we
+         * continue), or if we have completed processing the entire
+         * subtree, in which case traversal terminates. */
+        if (stack.empty())
+            return {++pos, false};
+    }
+
+    /* The user-provided traversal predicate did not at any point
+     * terminate traversal, but we nevertheless hit the end of the
+     * traversal range with portions of the subtree still left
+     * unexplored. */
+    return {last, true};
+}
+
+/*
+ * A MerkleProof is a transportable structure that contains the
+ * information necessary to verify the root of a Merkle tree given N
+ * accompanying "verify" hashes.  The proof consists of those portions
+ * of the tree which can't be pruned, and M "skip" hashes, each of
+ * which is either the root hash of a fully pruned subtree, or a leaf
+ * value not included in the set of "verify" hashes.
+ */
+struct MerkleProof
+{
+    typedef std::vector<MerkleNode> path_type;
+    path_type m_path;
+
+    typedef std::vector<uint256> skip_type;
+    skip_type m_skip;
+
+    MerkleProof(path_type&& path, skip_type&& skip) : m_path(path), m_skip(skip) { }
+
+    /* Default constructors and assignment operators are fine */
+    MerkleProof() = default;
+    MerkleProof(const MerkleProof&) = default;
+    MerkleProof(MerkleProof&&) = default;
+    MerkleProof& operator=(const MerkleProof&) = default;
+    MerkleProof& operator=(MerkleProof&&) = default;
+
+    void clear() noexcept;
+
+    ADD_SERIALIZE_METHODS;
+
+    template <typename Stream, typename Operation>
+    inline void SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
+        READWRITE(REF(m_path));
+        /* The standard serialization primitives for a vector involves
+         * using the Satoshi-defined CompactSize format, which isn't
+         * actually a very nice format to for most purposes when
+         * compared with the VarInt encoding developed by Pieter
+         * Wuille.  Since we have the freedom of defining a new
+         * serialization format for MerkleProofs, we choose to
+         * explicitly use the latter here. */
+        uint64_t skip_size = m_skip.size();
+        READWRITE(VARINT(skip_size));
+        if (ser_action.ForRead())
+            m_skip.resize(static_cast<skip_type::size_type>(skip_size));
+        /* Read/write hashes as plain old data. */
+        if (!m_skip.empty()) {
+            READWRITE(REF(CFlatData(m_skip)));
+        }
+    }
+};
+
+/* Defined outside the class for argument-dpendent lookup. */
+void swap(MerkleProof& lhs, MerkleProof& rhs);
+
+/*
+ * A MerkleTree combines a MerkleProof with a vector of "verify" hash
+ * values.  It also contains methods for re-computing the root hash.
+ */
+struct MerkleTree
+{
+    typedef MerkleProof proof_type;
+    proof_type m_proof;
+
+    typedef proof_type::skip_type verify_type;
+    verify_type m_verify;
+
+    /* Builds a new Merkle tree with the specified left-branch and
+     * right-branch, including properly handling the case of left or
+     * right being a single hash. */
+    MerkleTree(const MerkleTree& left, const MerkleTree& right);
+
+    /* Default constructors and assignment operators are fine */
+    MerkleTree() = default;
+    MerkleTree(const MerkleTree&) = default;
+    MerkleTree(MerkleTree&&) = default;
+    MerkleTree& operator=(const MerkleTree&) = default;
+    MerkleTree& operator=(MerkleTree&&) = default;
+
+    void clear() noexcept;
+
+    /* Calculates the root hash of the MerkleTree, a process that
+     * requires a depth first traverse of the full tree using linear
+     * time and logarithmic (depth) space.. */
+    uint256 GetHash(bool* invalid = nullptr) const;
+
+    ADD_SERIALIZE_METHODS;
+
+    template <typename Stream, typename Operation>
+    inline void SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
+        READWRITE(REF(m_proof));
+        /* See the note in MerkleProof about CompactSize vs VarInt. */
+        uint64_t verify_size = m_verify.size();
+        READWRITE(VARINT(verify_size));
+        if (ser_action.ForRead())
+            m_verify.resize(static_cast<verify_type::size_type>(verify_size));
+        /* Read/write hashes as plain old data. */
+        if (!m_verify.empty()) {
+            READWRITE(REF(CFlatData(m_verify)));
+        }
+    }
+};
+
+/* Defined outside the class for argument-dpendent lookup. */
+void swap(MerkleTree& lhs, MerkleTree& rhs);
+
+#endif // BITCOIN_MERKLE_PROOF
+
+// End of File

--- a/src/crypto/hmac_sha256.cpp
+++ b/src/crypto/hmac_sha256.cpp
@@ -40,6 +40,12 @@ CHMAC_SHA256::CHMAC_SHA256(const unsigned char* key, size_t keylen)
     inner.Write(rkey, 64);
 }
 
+void CHMAC_SHA256::Midstate(unsigned char hash[OUTPUT_SIZE*2], unsigned char* buffer, size_t* length)
+{
+    outer.Midstate(hash, NULL, NULL);
+    inner.Midstate(hash+OUTPUT_SIZE, buffer, length);
+}
+
 void CHMAC_SHA256::Finalize(unsigned char hash[OUTPUT_SIZE])
 {
     unsigned char temp[32];

--- a/src/crypto/hmac_sha256.h
+++ b/src/crypto/hmac_sha256.h
@@ -41,6 +41,7 @@ public:
         return *this;
     }
     void Finalize(unsigned char hash[OUTPUT_SIZE]);
+    void Midstate(unsigned char hash[OUTPUT_SIZE*2], unsigned char* buffer, size_t* length);
 };
 
 #endif // FREICOIN_CRYPTO_HMAC_SHA256_H

--- a/src/crypto/hmac_sha512.cpp
+++ b/src/crypto/hmac_sha512.cpp
@@ -40,6 +40,12 @@ CHMAC_SHA512::CHMAC_SHA512(const unsigned char* key, size_t keylen)
     inner.Write(rkey, 128);
 }
 
+void CHMAC_SHA512::Midstate(unsigned char hash[OUTPUT_SIZE*2], unsigned char* buffer, size_t* length)
+{
+    outer.Midstate(hash, NULL, NULL);
+    inner.Midstate(hash+OUTPUT_SIZE, buffer, length);
+}
+
 void CHMAC_SHA512::Finalize(unsigned char hash[OUTPUT_SIZE])
 {
     unsigned char temp[64];

--- a/src/crypto/hmac_sha512.h
+++ b/src/crypto/hmac_sha512.h
@@ -41,6 +41,7 @@ public:
         return *this;
     }
     void Finalize(unsigned char hash[OUTPUT_SIZE]);
+    void Midstate(unsigned char hash[OUTPUT_SIZE*2], unsigned char* buffer, size_t* length);
 };
 
 #endif // FREICOIN_CRYPTO_HMAC_SHA512_H

--- a/src/crypto/ripemd160.cpp
+++ b/src/crypto/ripemd160.cpp
@@ -291,11 +291,22 @@ void CRIPEMD160::Finalize(unsigned char hash[OUTPUT_SIZE])
     WriteLE64(sizedesc, bytes << 3);
     Write(pad, 1 + ((119 - (bytes % 64)) % 64));
     Write(sizedesc, 8);
+    Midstate(hash, NULL, NULL);
+}
+
+void CRIPEMD160::Midstate(unsigned char hash[OUTPUT_SIZE], unsigned char* buffer, size_t* length)
+{
     WriteLE32(hash, s[0]);
     WriteLE32(hash + 4, s[1]);
     WriteLE32(hash + 8, s[2]);
     WriteLE32(hash + 12, s[3]);
     WriteLE32(hash + 16, s[4]);
+    if (length) {
+        *length = bytes << 3;
+    }
+    if (buffer) {
+        memcpy(buffer, buf, bytes % 64);
+    }
 }
 
 CRIPEMD160& CRIPEMD160::Reset()

--- a/src/crypto/ripemd160.cpp
+++ b/src/crypto/ripemd160.cpp
@@ -258,6 +258,15 @@ CRIPEMD160::CRIPEMD160() : bytes(0)
     ripemd160::Initialize(s);
 }
 
+CRIPEMD160::CRIPEMD160(const unsigned char iv[OUTPUT_SIZE]) : bytes(0)
+{
+    s[0] = ReadLE32(iv);
+    s[1] = ReadLE32(iv + 4);
+    s[2] = ReadLE32(iv + 8);
+    s[3] = ReadLE32(iv + 12);
+    s[4] = ReadLE32(iv + 16);
+}
+
 CRIPEMD160& CRIPEMD160::Write(const unsigned char* data, size_t len)
 {
     const unsigned char* end = data + len;

--- a/src/crypto/ripemd160.h
+++ b/src/crypto/ripemd160.h
@@ -34,6 +34,7 @@ public:
     static const size_t OUTPUT_SIZE = 20;
 
     CRIPEMD160();
+    CRIPEMD160(const unsigned char iv[OUTPUT_SIZE]);
     CRIPEMD160& Write(const unsigned char* data, size_t len);
     void Finalize(unsigned char hash[OUTPUT_SIZE]);
     void Midstate(unsigned char hash[OUTPUT_SIZE], unsigned char* buffer, size_t* length);

--- a/src/crypto/ripemd160.h
+++ b/src/crypto/ripemd160.h
@@ -36,6 +36,7 @@ public:
     CRIPEMD160();
     CRIPEMD160& Write(const unsigned char* data, size_t len);
     void Finalize(unsigned char hash[OUTPUT_SIZE]);
+    void Midstate(unsigned char hash[OUTPUT_SIZE], unsigned char* buffer, size_t* length);
     CRIPEMD160& Reset();
 };
 

--- a/src/crypto/sha1.cpp
+++ b/src/crypto/sha1.cpp
@@ -165,6 +165,15 @@ CSHA1::CSHA1() : bytes(0)
     sha1::Initialize(s);
 }
 
+CSHA1::CSHA1(const unsigned char iv[OUTPUT_SIZE]) : bytes(0)
+{
+    s[0] = ReadBE32(iv);
+    s[1] = ReadBE32(iv + 4);
+    s[2] = ReadBE32(iv + 8);
+    s[3] = ReadBE32(iv + 12);
+    s[4] = ReadBE32(iv + 16);
+}
+
 CSHA1& CSHA1::Write(const unsigned char* data, size_t len)
 {
     const unsigned char* end = data + len;

--- a/src/crypto/sha1.cpp
+++ b/src/crypto/sha1.cpp
@@ -198,11 +198,22 @@ void CSHA1::Finalize(unsigned char hash[OUTPUT_SIZE])
     WriteBE64(sizedesc, bytes << 3);
     Write(pad, 1 + ((119 - (bytes % 64)) % 64));
     Write(sizedesc, 8);
+    Midstate(hash, NULL, NULL);
+}
+
+void CSHA1::Midstate(unsigned char hash[OUTPUT_SIZE], unsigned char* buffer, size_t* length)
+{
     WriteBE32(hash, s[0]);
     WriteBE32(hash + 4, s[1]);
     WriteBE32(hash + 8, s[2]);
     WriteBE32(hash + 12, s[3]);
     WriteBE32(hash + 16, s[4]);
+    if (length) {
+        *length = bytes << 3;
+    }
+    if (buffer) {
+        memcpy(buffer, buf, bytes % 64);
+    }
 }
 
 CSHA1& CSHA1::Reset()

--- a/src/crypto/sha1.h
+++ b/src/crypto/sha1.h
@@ -36,6 +36,7 @@ public:
     CSHA1();
     CSHA1& Write(const unsigned char* data, size_t len);
     void Finalize(unsigned char hash[OUTPUT_SIZE]);
+    void Midstate(unsigned char hash[OUTPUT_SIZE], unsigned char* buffer, size_t* length);
     CSHA1& Reset();
 };
 

--- a/src/crypto/sha1.h
+++ b/src/crypto/sha1.h
@@ -34,6 +34,7 @@ public:
     static const size_t OUTPUT_SIZE = 20;
 
     CSHA1();
+    CSHA1(const unsigned char iv[OUTPUT_SIZE]);
     CSHA1& Write(const unsigned char* data, size_t len);
     void Finalize(unsigned char hash[OUTPUT_SIZE]);
     void Midstate(unsigned char hash[OUTPUT_SIZE], unsigned char* buffer, size_t* length);

--- a/src/crypto/sha256.cpp
+++ b/src/crypto/sha256.cpp
@@ -185,6 +185,11 @@ void CSHA256::Finalize(unsigned char hash[OUTPUT_SIZE])
     WriteBE64(sizedesc, bytes << 3);
     Write(pad, 1 + ((119 - (bytes % 64)) % 64));
     Write(sizedesc, 8);
+    Midstate(hash, NULL, NULL);
+}
+
+void CSHA256::Midstate(unsigned char hash[OUTPUT_SIZE], unsigned char* buffer, size_t* length)
+{
     WriteBE32(hash, s[0]);
     WriteBE32(hash + 4, s[1]);
     WriteBE32(hash + 8, s[2]);
@@ -193,6 +198,12 @@ void CSHA256::Finalize(unsigned char hash[OUTPUT_SIZE])
     WriteBE32(hash + 20, s[5]);
     WriteBE32(hash + 24, s[6]);
     WriteBE32(hash + 28, s[7]);
+    if (length) {
+        *length = bytes << 3;
+    }
+    if (buffer) {
+        memcpy(buffer, buf, bytes % 64);
+    }
 }
 
 CSHA256& CSHA256::Reset()

--- a/src/crypto/sha256.cpp
+++ b/src/crypto/sha256.cpp
@@ -152,6 +152,18 @@ CSHA256::CSHA256() : bytes(0)
     sha256::Initialize(s);
 }
 
+CSHA256::CSHA256(const unsigned char iv[OUTPUT_SIZE]) : bytes(0)
+{
+    s[0] = ReadBE32(iv);
+    s[1] = ReadBE32(iv + 4);
+    s[2] = ReadBE32(iv + 8);
+    s[3] = ReadBE32(iv + 12);
+    s[4] = ReadBE32(iv + 16);
+    s[5] = ReadBE32(iv + 20);
+    s[6] = ReadBE32(iv + 24);
+    s[7] = ReadBE32(iv + 28);
+}
+
 CSHA256& CSHA256::Write(const unsigned char* data, size_t len)
 {
     const unsigned char* end = data + len;

--- a/src/crypto/sha256.h
+++ b/src/crypto/sha256.h
@@ -36,6 +36,7 @@ public:
     CSHA256();
     CSHA256& Write(const unsigned char* data, size_t len);
     void Finalize(unsigned char hash[OUTPUT_SIZE]);
+    void Midstate(unsigned char hash[OUTPUT_SIZE], unsigned char* buffer, size_t* length);
     CSHA256& Reset();
 };
 

--- a/src/crypto/sha256.h
+++ b/src/crypto/sha256.h
@@ -34,6 +34,7 @@ public:
     static const size_t OUTPUT_SIZE = 32;
 
     CSHA256();
+    CSHA256(const unsigned char iv[OUTPUT_SIZE]);
     CSHA256& Write(const unsigned char* data, size_t len);
     void Finalize(unsigned char hash[OUTPUT_SIZE]);
     void Midstate(unsigned char hash[OUTPUT_SIZE], unsigned char* buffer, size_t* length);

--- a/src/crypto/sha512.cpp
+++ b/src/crypto/sha512.cpp
@@ -203,6 +203,11 @@ void CSHA512::Finalize(unsigned char hash[OUTPUT_SIZE])
     WriteBE64(sizedesc + 8, bytes << 3);
     Write(pad, 1 + ((239 - (bytes % 128)) % 128));
     Write(sizedesc, 16);
+    Midstate(hash, NULL, NULL);
+}
+
+void CSHA512::Midstate(unsigned char hash[OUTPUT_SIZE], unsigned char* buffer, size_t* length)
+{
     WriteBE64(hash, s[0]);
     WriteBE64(hash + 8, s[1]);
     WriteBE64(hash + 16, s[2]);
@@ -211,6 +216,12 @@ void CSHA512::Finalize(unsigned char hash[OUTPUT_SIZE])
     WriteBE64(hash + 40, s[5]);
     WriteBE64(hash + 48, s[6]);
     WriteBE64(hash + 56, s[7]);
+    if (length) {
+        *length = bytes << 3;
+    }
+    if (buffer) {
+        memcpy(buffer, buf, bytes % 128);
+    }
 }
 
 CSHA512& CSHA512::Reset()

--- a/src/crypto/sha512.cpp
+++ b/src/crypto/sha512.cpp
@@ -170,6 +170,18 @@ CSHA512::CSHA512() : bytes(0)
     sha512::Initialize(s);
 }
 
+CSHA512::CSHA512(const unsigned char iv[OUTPUT_SIZE]) : bytes(0)
+{
+    s[0] = ReadBE64(iv);
+    s[1] = ReadBE64(iv + 4);
+    s[2] = ReadBE64(iv + 8);
+    s[3] = ReadBE64(iv + 12);
+    s[4] = ReadBE64(iv + 16);
+    s[5] = ReadBE64(iv + 20);
+    s[6] = ReadBE64(iv + 24);
+    s[7] = ReadBE64(iv + 28);
+}
+
 CSHA512& CSHA512::Write(const unsigned char* data, size_t len)
 {
     const unsigned char* end = data + len;

--- a/src/crypto/sha512.h
+++ b/src/crypto/sha512.h
@@ -36,6 +36,7 @@ public:
     CSHA512();
     CSHA512& Write(const unsigned char* data, size_t len);
     void Finalize(unsigned char hash[OUTPUT_SIZE]);
+    void Midstate(unsigned char hash[OUTPUT_SIZE], unsigned char* buffer, size_t* length);
     CSHA512& Reset();
 };
 

--- a/src/crypto/sha512.h
+++ b/src/crypto/sha512.h
@@ -34,6 +34,7 @@ public:
     static const size_t OUTPUT_SIZE = 64;
 
     CSHA512();
+    CSHA512(const unsigned char iv[OUTPUT_SIZE]);
     CSHA512& Write(const unsigned char* data, size_t len);
     void Finalize(unsigned char hash[OUTPUT_SIZE]);
     void Midstate(unsigned char hash[OUTPUT_SIZE], unsigned char* buffer, size_t* length);

--- a/src/test/merkle_tests.cpp
+++ b/src/test/merkle_tests.cpp
@@ -147,4 +147,44 @@ BOOST_AUTO_TEST_CASE(merkle_test)
     }
 }
 
+BOOST_AUTO_TEST_CASE(fast_merkle_branch)
+{
+    const std::vector<uint256> leaves = {
+      (CHashWriter(SER_GETHASH, PROTOCOL_VERSION) << 'a').GetHash(),
+      (CHashWriter(SER_GETHASH, PROTOCOL_VERSION) << 'b').GetHash(),
+      (CHashWriter(SER_GETHASH, PROTOCOL_VERSION) << 'c').GetHash(),
+    };
+    const uint256 root = ComputeFastMerkleRoot(leaves);
+    BOOST_CHECK(root == uint256S("0x9cde1ad752292baac9c86e91d0c0e506a3bc0e7f11fd449c8c54bbd3e46d91a1"));
+    {
+        std::vector<uint256> branch;
+        uint32_t path;
+        std::tie(branch, path) = ComputeFastMerkleBranch(leaves, 0);
+        BOOST_CHECK(path == 0);
+        BOOST_CHECK(branch.size() == 2);
+        BOOST_CHECK(branch[0] == leaves[1]);
+        BOOST_CHECK(branch[1] == leaves[2]);
+        BOOST_CHECK(root == ComputeFastMerkleRootFromBranch(leaves[0], branch, path));
+    }
+    {
+        std::vector<uint256> branch;
+        uint32_t path;
+        std::tie(branch, path) = ComputeFastMerkleBranch(leaves, 1);
+        BOOST_CHECK(path == 1);
+        BOOST_CHECK(branch.size() == 2);
+        BOOST_CHECK(branch[0] == leaves[0]);
+        BOOST_CHECK(branch[1] == leaves[2]);
+        BOOST_CHECK(root == ComputeFastMerkleRootFromBranch(leaves[1], branch, path));
+    }
+    {
+        std::vector<uint256> branch;
+        uint32_t path;
+        std::tie(branch, path) = ComputeFastMerkleBranch(leaves, 2);
+        BOOST_CHECK(path == 1);
+        BOOST_CHECK(branch.size() == 1);
+        BOOST_CHECK(branch[0] == uint256S("0xc771140365578d348d7ffc6e04a102ecf3e2eea51177d38fac92f954aebdd1cd"));
+        BOOST_CHECK(root == ComputeFastMerkleRootFromBranch(leaves[2], branch, path));
+    }
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/merkle_tests.cpp
+++ b/src/test/merkle_tests.cpp
@@ -17,6 +17,7 @@
 // <http://www.opensource.org/licenses/mit-license.php>
 
 #include "consensus/merkle.h"
+#include "consensus/merkleproof.h"
 #include "test/test_freicoin.h"
 #include "random.h"
 
@@ -147,8 +148,1034 @@ BOOST_AUTO_TEST_CASE(merkle_test)
     }
 }
 
+BOOST_AUTO_TEST_CASE(merkle_link)
+{
+    BOOST_CHECK(sizeof(MerkleLink) == 1);
+}
+
+BOOST_AUTO_TEST_CASE(merkle_node)
+{
+    BOOST_CHECK(sizeof(MerkleNode) == 1);
+
+    BOOST_CHECK(MerkleNode().GetCode() == 0);
+
+    const MerkleNode by_code[8] = {MerkleNode(0), MerkleNode(1), MerkleNode(2), MerkleNode(3), MerkleNode(4), MerkleNode(5), MerkleNode(6), MerkleNode(7)};
+    const MerkleNode by_link[8] = {
+        MerkleNode(MerkleLink::VERIFY, MerkleLink::SKIP),
+        MerkleNode(MerkleLink::VERIFY, MerkleLink::VERIFY),
+        MerkleNode(MerkleLink::VERIFY, MerkleLink::DESCEND),
+        MerkleNode(MerkleLink::DESCEND, MerkleLink::SKIP),
+        MerkleNode(MerkleLink::DESCEND, MerkleLink::VERIFY),
+        MerkleNode(MerkleLink::DESCEND, MerkleLink::DESCEND),
+        MerkleNode(MerkleLink::SKIP, MerkleLink::VERIFY),
+        MerkleNode(MerkleLink::SKIP, MerkleLink::DESCEND),
+    };
+
+    for (int i = 0; i <= 7; ++i) {
+        BOOST_CHECK(i == by_code[i].GetCode());
+        BOOST_CHECK(i == by_link[i].GetCode());
+    }
+
+    for (int i = 0; i <= 7; ++i) {
+        for (int j = 0; j <= 7; ++j) {
+            BOOST_CHECK((i==j) == (by_code[i] == by_link[j]));
+            BOOST_CHECK((i!=j) == (by_code[i] != by_link[j]));
+            BOOST_CHECK((i<j) == (by_code[i] < by_link[j]));
+            BOOST_CHECK((i<=j) == (by_code[i] <= by_link[j]));
+            BOOST_CHECK((i>=j) == (by_code[i] >= by_link[j]));
+            BOOST_CHECK((i>j) == (by_code[i] > by_link[j]));
+        }
+    }
+
+    MerkleNode a(0);
+    a.SetCode(1);
+    BOOST_CHECK(a.GetCode() == 1);
+    BOOST_CHECK(a == MerkleNode(1));
+
+    a = MerkleNode(3);
+    BOOST_CHECK(a != MerkleNode(1));
+    BOOST_CHECK(a.GetCode() == 3);
+
+    for (int i = 0; i <= 7; ++i) {
+        MerkleNode n = by_code[i];
+        MerkleLink l = n.GetLeft();
+        MerkleLink r = n.GetRight();
+        BOOST_CHECK(MerkleNode(l,r) == by_link[i]);
+        for (int j = 0; j <= 2; ++j) {
+          MerkleNode n2(n);
+          BOOST_CHECK(n2 == n);
+          n2.SetLeft(MerkleLink(j));
+          BOOST_CHECK(n2 == MerkleNode(MerkleLink(j),r));
+        }
+        for (int j = 0; j <= 2; ++j) {
+          MerkleNode n3(n);
+          BOOST_CHECK(n3 == n);
+          n3.SetRight(MerkleLink(j));
+          BOOST_CHECK(n3 == MerkleNode(l,MerkleLink(j)));
+        }
+    }
+}
+
+/*
+ * To properly test some features requires access to protected members
+ * of these classes. In the case of MerkleNode, just some static class
+ * members so we write a method to return those.
+ */
+struct PublicMerkleNode: public MerkleNode
+{
+    typedef const std::array<MerkleLink, 8> m_link_from_code_type;
+    static m_link_from_code_type& m_left_from_code()
+      { return MerkleNode::m_left_from_code; }
+    static m_link_from_code_type& m_right_from_code()
+      { return MerkleNode::m_right_from_code; }
+};
+
+/*
+ * In the case of MerkleNodeReference we need access to class instance
+ * members, so we have a somewhat more involve wrapper that is used
+ * for actual MerkleNodeReference instances (and forwards whatever
+ * functionality needs to be defined to the base class).
+ */
+struct PublicMerkleNodeReference: public MerkleNodeReference
+{
+    PublicMerkleNodeReference(base_type* base, offset_type offset) : MerkleNodeReference(base, offset) { }
+
+    PublicMerkleNodeReference() = delete;
+
+    PublicMerkleNodeReference(const PublicMerkleNodeReference& other) : MerkleNodeReference(other) { }
+    PublicMerkleNodeReference(const MerkleNodeReference& other) : MerkleNodeReference(other) { }
+    PublicMerkleNodeReference(PublicMerkleNodeReference&& other) : MerkleNodeReference(other) { }
+    PublicMerkleNodeReference(MerkleNodeReference&& other) : MerkleNodeReference(other) { }
+    inline PublicMerkleNodeReference& operator=(const PublicMerkleNodeReference& other)
+      { return static_cast<PublicMerkleNodeReference&>(MerkleNodeReference::operator=(other)); }
+    inline PublicMerkleNodeReference& operator=(const MerkleNodeReference& other)
+      { return static_cast<PublicMerkleNodeReference&>(MerkleNodeReference::operator=(other)); }
+    inline PublicMerkleNodeReference& operator=(PublicMerkleNodeReference&& other)
+      { return static_cast<PublicMerkleNodeReference&>(MerkleNodeReference::operator=(other)); }
+    inline PublicMerkleNodeReference& operator=(MerkleNodeReference&& other)
+      { return static_cast<PublicMerkleNodeReference&>(MerkleNodeReference::operator=(other)); }
+
+    inline PublicMerkleNodeReference& operator=(MerkleNode other)
+      { return static_cast<PublicMerkleNodeReference&>(MerkleNodeReference::operator=(other)); }
+    inline operator MerkleNode() const
+      { return MerkleNodeReference::operator MerkleNode(); }
+
+    typedef MerkleNodeReference::base_type* m_base_type;
+    m_base_type& m_base()
+      { return MerkleNodeReference::m_base; }
+    const m_base_type& m_base() const
+      { return MerkleNodeReference::m_base; }
+
+    typedef MerkleNodeReference::offset_type m_offset_type;
+    m_offset_type& m_offset()
+      { return MerkleNodeReference::m_offset; }
+    const m_offset_type& m_offset() const
+      { return MerkleNodeReference::m_offset; }
+};
+
+BOOST_AUTO_TEST_CASE(merkle_node_reference)
+{
+    MerkleNodeReference::base_type v[3] = {0};
+    PublicMerkleNodeReference _r[8] = {
+        {v, 0}, {v, 1}, {v, 2}, {v, 3},
+        {v, 4}, {v, 5}, {v, 6}, {v, 7},
+    };
+    MerkleNodeReference* r = &_r[0];
+    const MerkleNode n[8] = {
+        MerkleNode(0), MerkleNode(1), MerkleNode(2), MerkleNode(3),
+        MerkleNode(4), MerkleNode(5), MerkleNode(6), MerkleNode(7),
+    };
+
+    PublicMerkleNodeReference a(v, 0);
+    BOOST_CHECK(a.m_base() == &v[0]);
+    BOOST_CHECK(a.m_offset() == 0);
+
+    for (int i = 0; i <= 7; ++i) {
+        BOOST_CHECK(r[i].GetCode() == 0);
+        PublicMerkleNodeReference(v, i).SetCode(i);
+        BOOST_CHECK_MESSAGE(r[i].GetCode() == i, strprintf("%d", i).c_str());
+    }
+
+    BOOST_CHECK(v[0] == static_cast<MerkleNodeReference::base_type>(0x05));
+    BOOST_CHECK(v[1] == static_cast<MerkleNodeReference::base_type>(0x39));
+    BOOST_CHECK(v[2] == static_cast<MerkleNodeReference::base_type>(0x77));
+
+    for (int i = 0; i <= 7; ++i) {
+        BOOST_CHECK(n[i].GetCode() == i);
+        BOOST_CHECK(r[i].GetCode() == i);
+        BOOST_CHECK(r[i].GetLeft() == PublicMerkleNode::m_left_from_code()[i]);
+        BOOST_CHECK(r[i].GetRight() == PublicMerkleNode::m_right_from_code()[i]);
+    }
+
+    PublicMerkleNodeReference ref(v, 0);
+    PublicMerkleNodeReference ref2(v, 7);
+
+    for (MerkleNode::code_type i = 0; i <= 7; ++i) {
+        for (MerkleNode::code_type j = 0; j <= 7; ++j) {
+          ref.SetCode(i);
+          ref2.SetCode(j);
+          MerkleNode node(j);
+          BOOST_CHECK((i==j) == (ref == node));
+          BOOST_CHECK((j==i) == (node == ref));
+          BOOST_CHECK((i==j) == (ref == ref2));
+          BOOST_CHECK((i!=j) == (ref != node));
+          BOOST_CHECK((j!=i) == (node != ref));
+          BOOST_CHECK((i!=j) == (ref != ref2));
+          BOOST_CHECK((i<j) == (ref < node));
+          BOOST_CHECK((j<i) == (node < ref));
+          BOOST_CHECK((i<j) == (ref < ref2));
+          BOOST_CHECK((i<=j) == (ref <= node));
+          BOOST_CHECK((j<=i) == (node <= ref));
+          BOOST_CHECK((i<=j) == (ref <= ref2));
+          BOOST_CHECK((i>=j) == (ref >= node));
+          BOOST_CHECK((j>=i) == (node >= ref));
+          BOOST_CHECK((i>=j) == (ref >= ref2));
+          BOOST_CHECK((i>j) == (ref > node));
+          BOOST_CHECK((j>i) == (node > ref));
+          BOOST_CHECK((i>j) == (ref > ref2));
+          MerkleLink new_left = node.GetLeft();
+          MerkleLink new_right = node.GetRight();
+          if ((new_left == MerkleLink::SKIP) && (ref.GetRight() == MerkleLink::SKIP)) {
+              /* Prevent errors due to temporary {SKIP,SKIP} */
+              ref.SetRight(MerkleLink::VERIFY);
+          }
+          ref.SetLeft(new_left);
+          BOOST_CHECK(ref.GetLeft() == node.GetLeft());
+          if ((ref.GetLeft() == MerkleLink::SKIP) && (new_right == MerkleLink::SKIP)) {
+              /* Prevent errors due to temporary {SKIP,SKIP} */
+              ref.SetLeft(MerkleLink::VERIFY);
+          }
+          ref.SetRight(new_right);
+          BOOST_CHECK(ref.GetRight() == node.GetRight());
+          BOOST_CHECK(ref == node);
+          BOOST_CHECK(node == ref);
+          ref.SetCode(i);
+          BOOST_CHECK((i==j) == (ref == ref2));
+          ref2 = ref;
+          BOOST_CHECK(ref == ref2);
+          ref2 = node;
+          BOOST_CHECK(ref2 == node);
+          BOOST_CHECK((i==j) == (ref == ref2));
+          static_cast<MerkleNode>(ref).SetCode(j);
+          BOOST_CHECK((i==j) == (ref == ref2));
+        }
+    }
+}
+
+BOOST_AUTO_TEST_CASE(merkle_node_vector_constructor)
+{
+    /* explicit vector(const Allocator& alloc = Allocator()) */
+    std::vector<MerkleNode> def;
+    BOOST_CHECK(def.empty());
+    BOOST_CHECK(!def.dirty());
+
+    std::allocator<MerkleNode> alloc;
+    std::vector<MerkleNode> with_alloc(alloc);
+    BOOST_CHECK(with_alloc.get_allocator() == std::allocator<MerkleNode>());
+    BOOST_CHECK(with_alloc.get_allocator() == def.get_allocator());
+
+    /* explicit vector(size_type count) */
+    std::vector<MerkleNode> three(3);
+    BOOST_CHECK(three.size() == 3);
+    BOOST_CHECK(three[0] == MerkleNode());
+    BOOST_CHECK(three[1] == MerkleNode());
+    BOOST_CHECK(three[2] == MerkleNode());
+
+    std::vector<MerkleNode> nine(9);
+    BOOST_CHECK(nine.size() == 9);
+    BOOST_CHECK(nine.front() == MerkleNode());
+    BOOST_CHECK(nine.back() == MerkleNode());
+
+    /* vector(size_type count, value_type value, const Allocator& alloc = Allocator()) */
+    std::vector<MerkleNode> three_ones(3, MerkleNode(1));
+    BOOST_CHECK(three_ones.size() == 3);
+    BOOST_CHECK(three_ones[0] == MerkleNode(1));
+    BOOST_CHECK(three_ones[1] == MerkleNode(1));
+    BOOST_CHECK(three_ones[2] == MerkleNode(1));
+    BOOST_CHECK(three.size() == three_ones.size());
+    BOOST_CHECK(three != three_ones);
+
+    std::vector<MerkleNode> nine_sevens(9, MerkleNode(7), alloc);
+    BOOST_CHECK(nine_sevens.size() == 9);
+    BOOST_CHECK(nine_sevens.front() == MerkleNode(7));
+    BOOST_CHECK(nine_sevens.back() == MerkleNode(7));
+    BOOST_CHECK(nine.size() == nine_sevens.size());
+    BOOST_CHECK(nine != nine_sevens);
+
+    /* void assign(size_type count, value_type value) */
+    {
+        std::vector<MerkleNode> t(nine_sevens);
+        t.assign(3, MerkleNode(1));
+        BOOST_CHECK(t == three_ones);
+        std::vector<MerkleNode> t2(three_ones);
+        t2.assign(9, MerkleNode(7));
+        BOOST_CHECK(t2 == nine_sevens);
+    }
+
+    /* template<class InputIt> vector(InputIt first, InputIt last, const Allocator& alloc = Allocator()) */
+    std::vector<MerkleNode> one_two_three;
+    one_two_three.push_back(MerkleNode(1)); BOOST_CHECK(one_two_three[0].GetCode() == 1);
+    one_two_three.push_back(MerkleNode(2)); BOOST_CHECK(one_two_three[1].GetCode() == 2);
+    one_two_three.push_back(MerkleNode(3)); BOOST_CHECK(one_two_three[2].GetCode() == 3);
+
+    std::list<MerkleNode> l{MerkleNode(1), MerkleNode(2), MerkleNode(3)};
+    std::vector<MerkleNode> from_list(l.begin(), l.end());
+    BOOST_CHECK(from_list == one_two_three);
+
+    std::deque<MerkleNode> q{MerkleNode(3), MerkleNode(2), MerkleNode(1)};
+    std::vector<MerkleNode> from_reversed_deque(q.rbegin(), q.rend(), alloc);
+    BOOST_CHECK(from_reversed_deque == one_two_three);
+    BOOST_CHECK(from_reversed_deque == from_list);
+
+    /* template<class InputIt> void assign(InputIt first, InputIt last) */
+    {
+        std::vector<MerkleNode> t(nine_sevens);
+        t.assign(from_list.begin(), from_list.end());
+        BOOST_CHECK(t == one_two_three);
+        std::vector<MerkleNode> t2;
+        t2.assign(q.rbegin(), q.rend());
+        BOOST_CHECK(t2 == one_two_three);
+    }
+
+    /* vector(std::initializer_list<value_type> ilist, const Allocator& alloc = Allocator()) */
+    std::vector<MerkleNode> from_ilist{MerkleNode(1), MerkleNode(2), MerkleNode(3)};
+    BOOST_CHECK(from_ilist == one_two_three);
+
+    /* vector& operator=(std::initializer_list<value_type> ilist) */
+    {
+        std::vector<MerkleNode> t(nine_sevens);
+        t = {MerkleNode(1), MerkleNode(2), MerkleNode(3)};
+        BOOST_CHECK(t == one_two_three);
+    }
+
+    /* void assign(std::initializer_list<value_type> ilist) */
+    {
+        std::vector<MerkleNode> t(nine_sevens);
+        t.assign({MerkleNode(1), MerkleNode(2), MerkleNode(3)});
+        BOOST_CHECK(t == one_two_three);
+    }
+
+    /* vector(const vector& other) */
+    {
+        std::vector<MerkleNode> v123(one_two_three);
+        BOOST_CHECK(v123.size() == 3);
+        BOOST_CHECK(v123[0] == MerkleNode(1));
+        BOOST_CHECK(v123[1] == MerkleNode(2));
+        BOOST_CHECK(v123[2] == MerkleNode(3));
+        BOOST_CHECK(v123 == one_two_three);
+    }
+
+    /* vector(const vector& other, const Allocator& alloc) */
+    {
+        std::vector<MerkleNode> v123(one_two_three, alloc);
+        BOOST_CHECK(v123.size() == 3);
+        BOOST_CHECK(v123[0] == MerkleNode(1));
+        BOOST_CHECK(v123[1] == MerkleNode(2));
+        BOOST_CHECK(v123[2] == MerkleNode(3));
+        BOOST_CHECK(v123 == one_two_three);
+    }
+
+    /* vector(vector&& other) */
+    {
+        std::vector<MerkleNode> v123a(one_two_three);
+        BOOST_CHECK(v123a == one_two_three);
+        std::vector<MerkleNode> v123b(std::move(v123a));
+        BOOST_CHECK(v123b == one_two_three);
+    }
+
+    /* vector(vector&& other, const Allocator& alloc) */
+    {
+        std::vector<MerkleNode> v123a(one_two_three);
+        BOOST_CHECK(v123a == one_two_three);
+        std::vector<MerkleNode> v123b(std::move(v123a), alloc);
+        BOOST_CHECK(v123b == one_two_three);
+    }
+
+    /* vector& operator=(const vector& other) */
+    {
+        std::vector<MerkleNode> v123;
+        v123 = one_two_three;
+        BOOST_CHECK(v123.size() == 3);
+        BOOST_CHECK(v123[0] == MerkleNode(1));
+        BOOST_CHECK(v123[1] == MerkleNode(2));
+        BOOST_CHECK(v123[2] == MerkleNode(3));
+        BOOST_CHECK(v123 == one_two_three);
+    }
+
+    /* vector& operator=(vector&& other) */
+    {
+        std::vector<MerkleNode> v123;
+        v123 = std::move(one_two_three);
+        BOOST_CHECK(v123.size() == 3);
+        BOOST_CHECK(v123[0] == MerkleNode(1));
+        BOOST_CHECK(v123[1] == MerkleNode(2));
+        BOOST_CHECK(v123[2] == MerkleNode(3));
+    }
+}
+
+BOOST_AUTO_TEST_CASE(merkle_node_vector_relational)
+{
+    std::vector<MerkleNode> a{MerkleNode(0)};
+    std::vector<MerkleNode> b{MerkleNode(0), MerkleNode(1)};
+
+    BOOST_CHECK(!(a==b));
+    BOOST_CHECK(a!=b);
+    BOOST_CHECK(a<b);
+    BOOST_CHECK(a<=b);
+    BOOST_CHECK(!(a>=b));
+    BOOST_CHECK(!(a>b));
+
+    a.push_back(MerkleNode(1));
+
+    BOOST_CHECK(a==b);
+    BOOST_CHECK(!(a!=b));
+    BOOST_CHECK(!(a<b));
+    BOOST_CHECK(a<=b);
+    BOOST_CHECK(a>=b);
+    BOOST_CHECK(!(a>b));
+
+    a.push_back(MerkleNode(2));
+
+    BOOST_CHECK(!(a==b));
+    BOOST_CHECK(a!=b);
+    BOOST_CHECK(!(a<b));
+    BOOST_CHECK(!(a<=b));
+    BOOST_CHECK(a>=b);
+    BOOST_CHECK(a>b);
+}
+
+BOOST_AUTO_TEST_CASE(merkle_node_vector_access)
+{
+    std::vector<MerkleNode> v{MerkleNode(1), MerkleNode(2), MerkleNode(3)};
+    const std::vector<MerkleNode>& c = v;
+
+    BOOST_CHECK(v == c);
+
+    BOOST_CHECK(v.at(0) == MerkleNode(1));
+    BOOST_CHECK(c.at(0) == MerkleNode(1));
+    BOOST_CHECK(v.at(1) == MerkleNode(2));
+    BOOST_CHECK(v.at(1) == MerkleNode(2));
+    BOOST_CHECK(v.at(2) == MerkleNode(3));
+    BOOST_CHECK(v.at(2) == MerkleNode(3));
+
+    BOOST_CHECK_THROW(v.at(3), std::out_of_range);
+    BOOST_CHECK_THROW(c.at(3), std::out_of_range);
+
+    BOOST_CHECK(v[0] == MerkleNode(1));
+    BOOST_CHECK(c[0] == MerkleNode(1));
+    BOOST_CHECK(v[1] == MerkleNode(2));
+    BOOST_CHECK(c[1] == MerkleNode(2));
+    BOOST_CHECK(v[2] == MerkleNode(3));
+    BOOST_CHECK(c[2] == MerkleNode(3));
+
+    /* Known to work due to a weirdness of the packed format, used as
+     * a check that the access is not bounds checked. */
+    BOOST_CHECK(!v.dirty());
+    BOOST_CHECK(v[3] == MerkleNode(0));
+    BOOST_CHECK(!c.dirty());
+    BOOST_CHECK(c[3] == MerkleNode(0));
+
+    BOOST_CHECK(v.front() == MerkleNode(1));
+    BOOST_CHECK(c.front() == MerkleNode(1));
+    BOOST_CHECK(v.back() == MerkleNode(3));
+    BOOST_CHECK(c.back() == MerkleNode(3));
+
+    BOOST_CHECK(v.data()[0] == 0x29);
+    BOOST_CHECK(c.data()[0] == 0x29);
+    BOOST_CHECK(v.data()[1] == 0x80);
+    BOOST_CHECK(c.data()[1] == 0x80);
+}
+
+BOOST_AUTO_TEST_CASE(merkle_node_vector_iterator)
+{
+    std::vector<MerkleNode> v{MerkleNode(1), MerkleNode(2), MerkleNode(3)};
+    const std::vector<MerkleNode>& cv = v;
+
+    BOOST_CHECK(v.begin()[0] == MerkleNode(1));
+    BOOST_CHECK(v.begin()[1] == MerkleNode(2));
+    BOOST_CHECK(v.begin()[2] == MerkleNode(3));
+    BOOST_CHECK(*(2 + v.begin()) == MerkleNode(3));
+    auto i = v.begin();
+    BOOST_CHECK(*i++ == MerkleNode(1));
+    BOOST_CHECK(*i++ == MerkleNode(2));
+    BOOST_CHECK(*i++ == MerkleNode(3));
+    BOOST_CHECK(i-- == v.end());
+    BOOST_CHECK(*i-- == MerkleNode(3));
+    BOOST_CHECK(*i-- == MerkleNode(2));
+    BOOST_CHECK(*i == MerkleNode(1));
+    i += 2;
+    BOOST_CHECK(*i == MerkleNode(3));
+    BOOST_CHECK((i - v.begin()) == 2);
+    i -= 2;
+    BOOST_CHECK(i == v.begin());
+    BOOST_CHECK(std::distance(v.begin(), v.end()) == 3);
+    BOOST_CHECK((v.end() - v.begin()) == 3);
+
+    BOOST_CHECK(cv.begin()[0] == MerkleNode(1));
+    BOOST_CHECK(cv.begin()[1] == MerkleNode(2));
+    BOOST_CHECK(cv.begin()[2] == MerkleNode(3));
+    BOOST_CHECK(*(2 + cv.begin()) == MerkleNode(3));
+    auto c = cv.begin();
+    BOOST_CHECK(*c++ == MerkleNode(1));
+    BOOST_CHECK(*c++ == MerkleNode(2));
+    BOOST_CHECK(*c++ == MerkleNode(3));
+    BOOST_CHECK(c-- == cv.cend());
+    BOOST_CHECK(*c-- == MerkleNode(3));
+    BOOST_CHECK(*c-- == MerkleNode(2));
+    BOOST_CHECK(*c == MerkleNode(1));
+    c += 2;
+    BOOST_CHECK(*c == MerkleNode(3));
+    BOOST_CHECK((c - v.begin()) == 2);
+    c -= 2;
+    BOOST_CHECK(c == cv.begin());
+    BOOST_CHECK(std::distance(cv.begin(), cv.end()) == 3);
+    BOOST_CHECK((cv.end() - cv.begin()) == 3);
+
+    BOOST_CHECK(v.cbegin()[0] == MerkleNode(1));
+    BOOST_CHECK(v.cbegin()[1] == MerkleNode(2));
+    BOOST_CHECK(v.cbegin()[2] == MerkleNode(3));
+    BOOST_CHECK(*(2 + v.cbegin()) == MerkleNode(3));
+    auto c2 = v.cbegin();
+    BOOST_CHECK(*c2++ == MerkleNode(1));
+    BOOST_CHECK(*c2++ == MerkleNode(2));
+    BOOST_CHECK(*c2++ == MerkleNode(3));
+    BOOST_CHECK(c2-- == v.cend());
+    BOOST_CHECK(*c2-- == MerkleNode(3));
+    BOOST_CHECK(*c2-- == MerkleNode(2));
+    BOOST_CHECK(*c2 == MerkleNode(1));
+    c2 += 2;
+    BOOST_CHECK(*c2 == MerkleNode(3));
+    BOOST_CHECK((c2 - v.cbegin()) == 2);
+    c2 -= 2;
+    BOOST_CHECK(c2 == v.cbegin());
+    BOOST_CHECK(std::distance(v.cbegin(), v.cend()) == 3);
+    BOOST_CHECK((v.cend() - v.cbegin()) == 3);
+
+    BOOST_CHECK(v.rbegin()[0] == MerkleNode(3));
+    BOOST_CHECK(v.rbegin()[1] == MerkleNode(2));
+    BOOST_CHECK(v.rbegin()[2] == MerkleNode(1));
+    BOOST_CHECK(*(2 + v.rbegin()) == MerkleNode(1));
+    auto r = v.rbegin();
+    BOOST_CHECK(*r++ == MerkleNode(3));
+    BOOST_CHECK(*r++ == MerkleNode(2));
+    BOOST_CHECK(*r++ == MerkleNode(1));
+    BOOST_CHECK(r-- == v.rend());
+    BOOST_CHECK(*r-- == MerkleNode(1));
+    BOOST_CHECK(*r-- == MerkleNode(2));
+    BOOST_CHECK(*r == MerkleNode(3));
+    r += 2;
+    BOOST_CHECK(*r == MerkleNode(1));
+    BOOST_CHECK((r - v.rbegin()) == 2);
+    r -= 2;
+    BOOST_CHECK(r == v.rbegin());
+    BOOST_CHECK(std::distance(v.rbegin(), v.rend()) == 3);
+    BOOST_CHECK((v.rend() - v.rbegin()) == 3);
+
+    BOOST_CHECK(cv.rbegin()[0] == MerkleNode(3));
+    BOOST_CHECK(cv.rbegin()[1] == MerkleNode(2));
+    BOOST_CHECK(cv.rbegin()[2] == MerkleNode(1));
+    BOOST_CHECK(*(2 + cv.rbegin()) == MerkleNode(1));
+    auto rc = cv.rbegin();
+    BOOST_CHECK(*rc++ == MerkleNode(3));
+    BOOST_CHECK(*rc++ == MerkleNode(2));
+    BOOST_CHECK(*rc++ == MerkleNode(1));
+    BOOST_CHECK(rc-- == cv.rend());
+    BOOST_CHECK(*rc-- == MerkleNode(1));
+    BOOST_CHECK(*rc-- == MerkleNode(2));
+    BOOST_CHECK(*rc == MerkleNode(3));
+    rc += 2;
+    BOOST_CHECK(*rc == MerkleNode(1));
+    BOOST_CHECK((rc - cv.rbegin()) == 2);
+    rc -= 2;
+    BOOST_CHECK(rc == cv.rbegin());
+    BOOST_CHECK(std::distance(cv.rbegin(), cv.rend()) == 3);
+    BOOST_CHECK((cv.rend() - cv.rbegin()) == 3);
+
+    BOOST_CHECK(v.crbegin()[0] == MerkleNode(3));
+    BOOST_CHECK(v.crbegin()[1] == MerkleNode(2));
+    BOOST_CHECK(v.crbegin()[2] == MerkleNode(1));
+    BOOST_CHECK(*(2 + v.crbegin()) == MerkleNode(1));
+    auto rc2 = v.crbegin();
+    BOOST_CHECK(*rc2++ == MerkleNode(3));
+    BOOST_CHECK(*rc2++ == MerkleNode(2));
+    BOOST_CHECK(*rc2++ == MerkleNode(1));
+    BOOST_CHECK(rc2-- == v.crend());
+    BOOST_CHECK(*rc2-- == MerkleNode(1));
+    BOOST_CHECK(*rc2-- == MerkleNode(2));
+    BOOST_CHECK(*rc2 == MerkleNode(3));
+    rc2 += 2;
+    BOOST_CHECK(*rc2 == MerkleNode(1));
+    BOOST_CHECK((rc2 - v.crbegin()) == 2);
+    rc2 -= 2;
+    BOOST_CHECK(rc2 == v.crbegin());
+    BOOST_CHECK(std::distance(v.crbegin(), v.crend()) == 3);
+    BOOST_CHECK((v.crend() - v.crbegin()) == 3);
+}
+
+BOOST_AUTO_TEST_CASE(merkle_node_vector_capacity)
+{
+    std::vector<MerkleNode> v;
+    BOOST_CHECK(v.empty());
+    BOOST_CHECK(v.size() == 0);
+    BOOST_CHECK(v.max_size() >= std::vector<unsigned char>().max_size());
+    BOOST_CHECK(v.capacity() >= v.size());
+
+    v.push_back(MerkleNode(1));
+    BOOST_CHECK(!v.empty());
+    BOOST_CHECK(v.size() == 1);
+    BOOST_CHECK(v.capacity() >= v.size());
+
+    v.push_back(MerkleNode(2));
+    BOOST_CHECK(!v.empty());
+    BOOST_CHECK(v.size() == 2);
+    BOOST_CHECK(v.capacity() >= v.size());
+
+    v.push_back(MerkleNode(3));
+    BOOST_CHECK(!v.empty());
+    BOOST_CHECK(v.size() == 3);
+    BOOST_CHECK(v.capacity() >= v.size());
+
+    BOOST_CHECK(v == std::vector<MerkleNode>({MerkleNode(1), MerkleNode(2), MerkleNode(3)}));
+
+    v.resize(6);
+    BOOST_CHECK(!v.empty());
+    BOOST_CHECK(v.size() == 6);
+    BOOST_CHECK(v.capacity() >= v.size());
+
+    BOOST_CHECK(v == std::vector<MerkleNode>({MerkleNode(1), MerkleNode(2), MerkleNode(3),
+                                              MerkleNode(0), MerkleNode(0), MerkleNode(0)}));
+
+    v.shrink_to_fit();
+    BOOST_CHECK(v == std::vector<MerkleNode>({MerkleNode(1), MerkleNode(2), MerkleNode(3),
+                                              MerkleNode(0), MerkleNode(0), MerkleNode(0)}));
+
+    v.resize(9, MerkleNode(7));
+    BOOST_CHECK(v == std::vector<MerkleNode>({MerkleNode(1), MerkleNode(2), MerkleNode(3),
+                                              MerkleNode(0), MerkleNode(0), MerkleNode(0),
+                                              MerkleNode(7), MerkleNode(7), MerkleNode(7)}));
+
+    v.shrink_to_fit();
+    BOOST_CHECK(v == std::vector<MerkleNode>({MerkleNode(1), MerkleNode(2), MerkleNode(3),
+                                              MerkleNode(0), MerkleNode(0), MerkleNode(0),
+                                              MerkleNode(7), MerkleNode(7), MerkleNode(7)}));
+
+    v.resize(3);
+    BOOST_CHECK(v == std::vector<MerkleNode>({MerkleNode(1), MerkleNode(2), MerkleNode(3)}));
+}
+
+/*
+ * Takes an iterator of any category derived from InputIterator, and
+ * exposes an interface restricted to only support the InputIterator
+ * API, including the input_iterator_tag. Useful for mocking an
+ * InputIterator for testing non-random-access or non-bidirectional
+ * code paths.
+ */
+template<class Iter>
+struct mock_input_iterator: public std::iterator<std::input_iterator_tag, typename Iter::reference>
+{
+    typedef Iter inner_type;
+    inner_type m_iter;
+
+    typedef mock_input_iterator iterator;
+    typedef typename inner_type::value_type value_type;
+    typedef typename inner_type::difference_type difference_type;
+    typedef typename inner_type::pointer pointer;
+    typedef typename inner_type::reference reference;
+
+    mock_input_iterator() = delete;
+
+    explicit mock_input_iterator(inner_type& iter) : m_iter(iter) { }
+
+    iterator& operator=(inner_type& iter)
+    {
+        m_iter = iter;
+        return *this;
+    }
+
+    mock_input_iterator(const iterator&) = default;
+    mock_input_iterator(iterator&&) = default;
+    iterator& operator=(const iterator&) = default;
+    iterator& operator=(iterator&&) = default;
+
+    /* Distance */
+    difference_type operator-(const iterator& other) const
+      { return (m_iter - other.m_iter); }
+
+    /* Equality */
+    inline bool operator==(const iterator& other) const
+      { return (m_iter == other.m_iter); }
+    inline bool operator!=(const iterator& other) const
+      { return (m_iter != other.m_iter); }
+
+    /* Input iterators are not relational comparable */
+
+    /* Dereference */
+    inline reference operator*() const
+      { return (*m_iter); }
+    inline pointer operator->() const
+      { return m_iter.operator->(); }
+
+    /* Advancement */
+    inline iterator& operator++()
+    {
+        m_iter.operator++();
+        return *this;
+    }
+
+    inline iterator& operator++(int _)
+      { return iterator(m_iter.operator++(_)); }
+};
+
+template<class Iter>
+inline mock_input_iterator<Iter> wrap_mock_input_iterator(Iter iter)
+  { return mock_input_iterator<Iter>(iter); }
+
+BOOST_AUTO_TEST_CASE(merkle_node_vector_insert)
+{
+    /* void push_back(value_type value) */
+    /* template<class... Args> void emplace_back(Args&&... args) */
+    std::vector<MerkleNode> one_two_three;
+    one_two_three.push_back(MerkleNode(1));
+    one_two_three.emplace_back(static_cast<MerkleNode::code_type>(2));
+    one_two_three.emplace_back(MerkleLink::DESCEND, MerkleLink::SKIP);
+    BOOST_CHECK(one_two_three.size() == 3);
+    BOOST_CHECK(one_two_three[0] == MerkleNode(1));
+    BOOST_CHECK(one_two_three[1] == MerkleNode(2));
+    BOOST_CHECK(one_two_three[2] == MerkleNode(3));
+
+    /* void clear() */
+    {
+        std::vector<MerkleNode> v(one_two_three);
+        BOOST_CHECK(v.size() == 3);
+        BOOST_CHECK(v == one_two_three);
+        v.clear();
+        BOOST_CHECK(v.empty());
+        BOOST_CHECK(one_two_three.size() == 3);
+    }
+
+    /* iterator insert(const_iterator pos, value_type value) */
+    {
+        std::vector<MerkleNode> v(one_two_three);
+        auto res = v.insert(v.begin(), MerkleNode(0));
+        BOOST_CHECK(res == v.begin());
+        BOOST_CHECK(v != one_two_three);
+        BOOST_CHECK(v == std::vector<MerkleNode>({MerkleNode(0), MerkleNode(1), MerkleNode(2), MerkleNode(3)}));
+        res = v.insert(v.begin()+2, MerkleNode(4));
+        BOOST_CHECK(res == (v.begin()+2));
+        BOOST_CHECK(v == std::vector<MerkleNode>({MerkleNode(0), MerkleNode(1), MerkleNode(4), MerkleNode(2), MerkleNode(3)}));
+        res = v.insert(v.begin()+4, MerkleNode(5));
+        BOOST_CHECK(res == (v.begin()+4));
+        BOOST_CHECK(v == std::vector<MerkleNode>({MerkleNode(0), MerkleNode(1), MerkleNode(4), MerkleNode(2), MerkleNode(5), MerkleNode(3)}));
+        res = v.insert(v.begin()+6, MerkleNode(6));
+        BOOST_CHECK(res == (v.begin()+6));
+        BOOST_CHECK(v == std::vector<MerkleNode>({MerkleNode(0), MerkleNode(1), MerkleNode(4), MerkleNode(2), MerkleNode(5), MerkleNode(3), MerkleNode(6)}));
+        res = v.insert(v.end(), MerkleNode(7));
+        BOOST_CHECK(res != v.end());
+        BOOST_CHECK(res == (v.begin()+7));
+        BOOST_CHECK(v == std::vector<MerkleNode>({MerkleNode(0), MerkleNode(1), MerkleNode(4), MerkleNode(2), MerkleNode(5), MerkleNode(3), MerkleNode(6), MerkleNode(7)}));
+    }
+
+    /* iterator insert(const_iterator pos, size_type count, value_type value) */
+    {
+        std::vector<MerkleNode> v(one_two_three);
+        auto res = v.insert(v.begin(), 0, MerkleNode(0));
+        BOOST_CHECK(res == v.begin());
+        BOOST_CHECK(v == one_two_three);
+        res = v.insert(v.begin()+1, 1, MerkleNode(4));
+        BOOST_CHECK(res == (v.begin()+1));
+        BOOST_CHECK(v == std::vector<MerkleNode>({MerkleNode(1), MerkleNode(4), MerkleNode(2), MerkleNode(3)}));
+        res = v.insert(v.begin()+3, 2, MerkleNode(5));
+        BOOST_CHECK(res == (v.begin()+3));
+        BOOST_CHECK(v == std::vector<MerkleNode>({MerkleNode(1), MerkleNode(4), MerkleNode(2), MerkleNode(5), MerkleNode(5), MerkleNode(3)}));
+        res = v.insert(v.begin()+6, 3, MerkleNode(6));
+        BOOST_CHECK(res == (v.begin()+6));
+        BOOST_CHECK(v == std::vector<MerkleNode>({MerkleNode(1), MerkleNode(4), MerkleNode(2), MerkleNode(5), MerkleNode(5), MerkleNode(3), MerkleNode(6), MerkleNode(6), MerkleNode(6)}));
+        res = v.insert(v.end(), 2, MerkleNode(7));
+        BOOST_CHECK(res != v.end());
+        BOOST_CHECK(res == (v.begin()+9));
+        BOOST_CHECK(v == std::vector<MerkleNode>({MerkleNode(1), MerkleNode(4), MerkleNode(2), MerkleNode(5), MerkleNode(5), MerkleNode(3), MerkleNode(6), MerkleNode(6), MerkleNode(6), MerkleNode(7), MerkleNode(7)}));
+    }
+
+    /* template<class InputIt> iterator insert(const_iterator pos, InputIt first, InputIt last) */
+    {
+        std::vector<MerkleNode> ones({MerkleNode(1), MerkleNode(1)});
+        std::vector<MerkleNode> twos({MerkleNode(2), MerkleNode(2)});
+        std::vector<MerkleNode> v;
+        BOOST_CHECK(v.empty());
+        auto res = v.insert(v.begin(), wrap_mock_input_iterator(ones.begin()), wrap_mock_input_iterator(ones.end()));
+        BOOST_CHECK(res == v.begin());
+        BOOST_CHECK(v == std::vector<MerkleNode>({MerkleNode(1), MerkleNode(1)}));
+        res = v.insert(v.begin()+1, one_two_three.begin(), one_two_three.end());
+        BOOST_CHECK(res == (v.begin()+1));
+        BOOST_CHECK(v == std::vector<MerkleNode>({MerkleNode(1), MerkleNode(1), MerkleNode(2), MerkleNode(3), MerkleNode(1)}));
+        res = v.insert(v.end(), twos.begin(), twos.begin() + 1);
+        BOOST_CHECK(res != v.end());
+        BOOST_CHECK(res == (v.begin()+5));
+        BOOST_CHECK(v == std::vector<MerkleNode>({MerkleNode(1), MerkleNode(1), MerkleNode(2), MerkleNode(3), MerkleNode(1), MerkleNode(2)}));
+        std::vector<MerkleNode> v2(v);
+        res = v2.insert(v2.end(), v.begin(), v.end());
+        BOOST_CHECK(res != v2.end());
+        BOOST_CHECK(res == (v2.begin()+6));
+        BOOST_CHECK(v2 == std::vector<MerkleNode>({MerkleNode(1), MerkleNode(1), MerkleNode(2), MerkleNode(3), MerkleNode(1), MerkleNode(2), MerkleNode(1), MerkleNode(1), MerkleNode(2), MerkleNode(3), MerkleNode(1), MerkleNode(2)}));
+        std::vector<MerkleNode> v3(v2);
+        res = v3.insert(v3.begin()+1, v2.begin(), v2.end());
+        BOOST_CHECK(res == (v3.begin()+1));
+        BOOST_CHECK(v3 == std::vector<MerkleNode>({MerkleNode(1), MerkleNode(1), MerkleNode(1), MerkleNode(2), MerkleNode(3), MerkleNode(1), MerkleNode(2), MerkleNode(1), MerkleNode(1), MerkleNode(2), MerkleNode(3), MerkleNode(1), MerkleNode(2), MerkleNode(1), MerkleNode(2), MerkleNode(3), MerkleNode(1), MerkleNode(2), MerkleNode(1), MerkleNode(1), MerkleNode(2), MerkleNode(3), MerkleNode(1), MerkleNode(2)}));
+        res = v3.insert(v3.begin(), one_two_three.begin(), one_two_three.end());
+        BOOST_CHECK(res == v3.begin());
+        BOOST_CHECK(v3 == std::vector<MerkleNode>({MerkleNode(1), MerkleNode(2), MerkleNode(3), MerkleNode(1), MerkleNode(1), MerkleNode(1), MerkleNode(2), MerkleNode(3), MerkleNode(1), MerkleNode(2), MerkleNode(1), MerkleNode(1), MerkleNode(2), MerkleNode(3), MerkleNode(1), MerkleNode(2), MerkleNode(1), MerkleNode(2), MerkleNode(3), MerkleNode(1), MerkleNode(2), MerkleNode(1), MerkleNode(1), MerkleNode(2), MerkleNode(3), MerkleNode(1), MerkleNode(2)}));
+    }
+
+    /* iterator insert(const_iterator pos, std::initializer_list<value_type> ilist) */
+    {
+        std::vector<MerkleNode> v;
+        auto res = v.insert(v.begin(), {MerkleNode(1), MerkleNode(1)});
+        BOOST_CHECK(res == v.begin());
+        BOOST_CHECK(v == std::vector<MerkleNode>({MerkleNode(1), MerkleNode(1)}));
+        res = v.insert(v.begin()+1, {MerkleNode(2), MerkleNode(2)});
+        BOOST_CHECK(res == (v.begin()+1));
+        BOOST_CHECK(v == std::vector<MerkleNode>({MerkleNode(1), MerkleNode(2), MerkleNode(2), MerkleNode(1)}));
+        res = v.insert(v.end(), {MerkleNode(3)});
+        BOOST_CHECK(res == (v.begin()+4));
+        BOOST_CHECK(v == std::vector<MerkleNode>({MerkleNode(1), MerkleNode(2), MerkleNode(2), MerkleNode(1), MerkleNode(3)}));
+    }
+
+    /* template<class... Args> iterator emplace(const_iterator pos, Args&&... args) */
+    {
+        std::vector<MerkleNode> v;
+        auto res = v.emplace(v.begin());
+        BOOST_CHECK(res == v.begin());
+        BOOST_CHECK(v == std::vector<MerkleNode>({MerkleNode(0)}));
+        res = v.emplace(v.end(), MerkleNode(2));
+        BOOST_CHECK(res != v.end());
+        BOOST_CHECK(res == (v.begin()+1));
+        BOOST_CHECK(v == std::vector<MerkleNode>({MerkleNode(0), MerkleNode(2)}));
+        res = v.emplace(res, static_cast<MerkleNode::code_type>(1));
+        BOOST_CHECK(res == (v.begin()+1));
+        BOOST_CHECK(v == std::vector<MerkleNode>({MerkleNode(0), MerkleNode(1), MerkleNode(2)}));
+        res = v.emplace(v.end(), MerkleLink::DESCEND, MerkleLink::SKIP);
+        BOOST_CHECK(res != v.end());
+        BOOST_CHECK(res == (v.begin()+3));
+        BOOST_CHECK(v == std::vector<MerkleNode>({MerkleNode(0), MerkleNode(1), MerkleNode(2), MerkleNode(3)}));
+    }
+
+    /* iterator erase(const_iterator pos) */
+    {
+        std::vector<MerkleNode> v(one_two_three);
+        auto res = v.erase(v.begin()+1);
+        BOOST_CHECK(res == (v.begin()+1));
+        BOOST_CHECK(v == std::vector<MerkleNode>({MerkleNode(1), MerkleNode(3)}));
+        res = v.erase(v.begin());
+        BOOST_CHECK(res == v.begin());
+        BOOST_CHECK(v == std::vector<MerkleNode>({MerkleNode(3)}));
+    }
+
+    /* iterator erase(const_iterator first, const_iterator last) */
+    {
+        std::vector<MerkleNode> v(one_two_three);
+        auto res = v.erase(v.begin()+1, v.end());
+        BOOST_CHECK(res == v.end());
+        BOOST_CHECK(res == (v.begin()+1));
+        BOOST_CHECK(v == std::vector<MerkleNode>({MerkleNode(1)}));
+    }
+
+    /* void pop_back() */
+    {
+        std::vector<MerkleNode> v;
+        v.insert(v.end(), one_two_three.begin(), one_two_three.end());
+        v.insert(v.end(), one_two_three.begin(), one_two_three.end());
+        v.insert(v.end(), one_two_three.begin(), one_two_three.end());
+        BOOST_CHECK(v.size() == 9);
+        BOOST_CHECK(v == std::vector<MerkleNode>({MerkleNode(1), MerkleNode(2), MerkleNode(3),
+                                                  MerkleNode(1), MerkleNode(2), MerkleNode(3),
+                                                  MerkleNode(1), MerkleNode(2), MerkleNode(3)}));
+        v.pop_back();
+        BOOST_CHECK(v.size() == 8);
+        BOOST_CHECK(v == std::vector<MerkleNode>({MerkleNode(1), MerkleNode(2), MerkleNode(3),
+                                                  MerkleNode(1), MerkleNode(2), MerkleNode(3),
+                                                  MerkleNode(1), MerkleNode(2)}));
+        v.pop_back();
+        BOOST_CHECK(v.size() == 7);
+        BOOST_CHECK(v == std::vector<MerkleNode>({MerkleNode(1), MerkleNode(2), MerkleNode(3),
+                                                  MerkleNode(1), MerkleNode(2), MerkleNode(3),
+                                                  MerkleNode(1)}));
+        v.pop_back();
+        BOOST_CHECK(v.size() == 6);
+        BOOST_CHECK(v == std::vector<MerkleNode>({MerkleNode(1), MerkleNode(2), MerkleNode(3),
+                                                  MerkleNode(1), MerkleNode(2), MerkleNode(3)}));
+        v.pop_back();
+        BOOST_CHECK(v.size() == 5);
+        BOOST_CHECK(v == std::vector<MerkleNode>({MerkleNode(1), MerkleNode(2), MerkleNode(3),
+                                                  MerkleNode(1), MerkleNode(2)}));
+        v.pop_back();
+        BOOST_CHECK(v.size() == 4);
+        BOOST_CHECK(v == std::vector<MerkleNode>({MerkleNode(1), MerkleNode(2), MerkleNode(3),
+                                                  MerkleNode(1)}));
+        v.pop_back();
+        BOOST_CHECK(v.size() == 3);
+        BOOST_CHECK(v == std::vector<MerkleNode>({MerkleNode(1), MerkleNode(2), MerkleNode(3)}));
+        v.pop_back();
+        BOOST_CHECK(v.size() == 2);
+        BOOST_CHECK(v == std::vector<MerkleNode>({MerkleNode(1), MerkleNode(2)}));
+        v.pop_back();
+        BOOST_CHECK(v.size() == 1);
+        BOOST_CHECK(v == std::vector<MerkleNode>(1, MerkleNode(1)));
+        v.pop_back();
+        BOOST_CHECK(v.empty());
+        BOOST_CHECK(v == std::vector<MerkleNode>());
+    }
+
+    /* void swap(vector& other) */
+    {
+        std::vector<MerkleNode> tmp;
+        BOOST_CHECK(tmp.empty());
+        tmp.swap(one_two_three);
+        BOOST_CHECK(tmp.size() == 3);
+    }
+    BOOST_CHECK(one_two_three.empty());
+}
+
+BOOST_AUTO_TEST_CASE(merkle_node_vector_dirty)
+{
+    static std::size_t k_vch_size[9] =
+      {0, 1, 1, 2, 2, 2, 3, 3, 3};
+
+    for (std::size_t i = 1; i <= 8; ++i) {
+        std::vector<MerkleNode> v;
+        for (std::size_t j = 0; j < i; ++j)
+            v.emplace_back(static_cast<MerkleNode::code_type>(j));
+        for (std::size_t j = 0; j < (8*k_vch_size[i]); ++j) {
+            BOOST_CHECK(!v.dirty());
+            v.data()[j/8] ^= (1 << (7-(j%8)));
+            BOOST_CHECK((j < (3*i)) == !(v.dirty()));
+            v.data()[j/8] ^= (1 << (7-(j%8)));
+        }
+    }
+}
+
+BOOST_AUTO_TEST_CASE(merkle_node_vector_serialize)
+{
+    std::vector<MerkleNode> v;
+    {
+        CDataStream ds(SER_NETWORK, PROTOCOL_VERSION);
+        ds << v;
+        BOOST_CHECK(std::equal(ds.begin(), ds.end(), "\x00"));
+        std::vector<MerkleNode> v2;
+        ds >> v2;
+        BOOST_CHECK(v == v2);
+    }
+
+    v.emplace_back(0);
+    {
+        CDataStream ds(SER_NETWORK, PROTOCOL_VERSION);
+        ds << v;
+        BOOST_CHECK(std::equal(ds.begin(), ds.end(), "\x01\x00"));
+        std::vector<MerkleNode> v2;
+        ds >> v2;
+        BOOST_CHECK(v == v2);
+    }
+
+    v.emplace_back(1);
+    {
+        CDataStream ds(SER_NETWORK, PROTOCOL_VERSION);
+        ds << v;
+        BOOST_CHECK(std::equal(ds.begin(), ds.end(), "\x02\x04"));
+        std::vector<MerkleNode> v2;
+        ds >> v2;
+        BOOST_CHECK(v == v2);
+    }
+
+    v.emplace_back(2);
+    {
+        CDataStream ds(SER_NETWORK, PROTOCOL_VERSION);
+        ds << v;
+        BOOST_CHECK(std::equal(ds.begin(), ds.end(), "\x03\x05\x00"));
+        std::vector<MerkleNode> v2;
+        ds >> v2;
+        BOOST_CHECK(v == v2);
+    }
+
+    v.emplace_back(3);
+    {
+        CDataStream ds(SER_NETWORK, PROTOCOL_VERSION);
+        ds << v;
+        BOOST_CHECK(std::equal(ds.begin(), ds.end(), "\x04\x05\x30"));
+        std::vector<MerkleNode> v2;
+        ds >> v2;
+        BOOST_CHECK(v == v2);
+    }
+
+    v.emplace_back(4);
+    {
+        CDataStream ds(SER_NETWORK, PROTOCOL_VERSION);
+        ds << v;
+        BOOST_CHECK(std::equal(ds.begin(), ds.end(), "\x05\x05\x38"));
+        std::vector<MerkleNode> v2;
+        ds >> v2;
+        BOOST_CHECK(v == v2);
+    }
+
+    v.emplace_back(5);
+    {
+        CDataStream ds(SER_NETWORK, PROTOCOL_VERSION);
+        ds << v;
+        BOOST_CHECK(std::equal(ds.begin(), ds.end(), "\x06\x05\x39\x40"));
+        std::vector<MerkleNode> v2;
+        ds >> v2;
+        BOOST_CHECK(v == v2);
+    }
+
+    v.emplace_back(6);
+    {
+        CDataStream ds(SER_NETWORK, PROTOCOL_VERSION);
+        ds << v;
+        BOOST_CHECK(std::equal(ds.begin(), ds.end(), "\x07\x05\x39\x70"));
+        std::vector<MerkleNode> v2;
+        ds >> v2;
+        BOOST_CHECK(v == v2);
+    }
+
+    v.emplace_back(7);
+    {
+        CDataStream ds(SER_NETWORK, PROTOCOL_VERSION);
+        ds << v;
+        BOOST_CHECK(std::equal(ds.begin(), ds.end(), "\x08\x05\x39\x77"));
+        std::vector<MerkleNode> v2;
+        ds >> v2;
+        BOOST_CHECK(v == v2);
+    }
+
+    v.emplace_back(5);
+    {
+        CDataStream ds(SER_NETWORK, PROTOCOL_VERSION);
+        ds << v;
+        BOOST_CHECK(std::equal(ds.begin(), ds.end(), "\x09\x05\x39\x77\xa0"));
+        std::vector<MerkleNode> v2;
+        ds >> v2;
+        BOOST_CHECK(v == v2);
+    }
+
+    {
+        auto data = ParseHex("02600239361160903c6695c6804b7157c7bd10013e9ba89b1f954243bc8e3990b08db96632753d6ca30fea890f37fc150eaed8d068acf596acb2251b8fafd72db977d3");
+        CDataStream ds(SER_NETWORK, PROTOCOL_VERSION);
+        ds << CFlatData(data.data(), data.data()+data.size());
+        MerkleProof proof;
+        BOOST_CHECK_MESSAGE(ds[0] == '\x02', HexStr(ds.begin(), ds.end()).c_str());
+        BOOST_CHECK_MESSAGE(ds.size() == 67, HexStr(ds.begin(), ds.end()).c_str());
+        ds >> proof;
+        BOOST_CHECK(ds.empty());
+        BOOST_CHECK(proof.m_path.size() == 2);
+        BOOST_CHECK(proof.m_path[0] == MerkleNode(MerkleLink::DESCEND, MerkleLink::SKIP));
+        BOOST_CHECK(proof.m_path[1] == MerkleNode(MerkleLink::VERIFY, MerkleLink::SKIP));
+        BOOST_CHECK(proof.m_skip.size() == 2);
+        BOOST_CHECK(proof.m_skip[0] == uint256S("b98db090398ebc4342951f9ba89b3e0110bdc757714b80c695663c9060113639"));
+        BOOST_CHECK(proof.m_skip[1] == uint256S("d377b92dd7af8f1b25b2ac96f5ac68d0d8ae0e15fc370f89ea0fa36c3d753266"));
+    }
+}
+
 BOOST_AUTO_TEST_CASE(fast_merkle_branch)
 {
+    using std::swap;
     const std::vector<uint256> leaves = {
       (CHashWriter(SER_GETHASH, PROTOCOL_VERSION) << 'a').GetHash(),
       (CHashWriter(SER_GETHASH, PROTOCOL_VERSION) << 'b').GetHash(),
@@ -184,6 +1211,44 @@ BOOST_AUTO_TEST_CASE(fast_merkle_branch)
         BOOST_CHECK(branch.size() == 1);
         BOOST_CHECK(branch[0] == uint256S("0xc771140365578d348d7ffc6e04a102ecf3e2eea51177d38fac92f954aebdd1cd"));
         BOOST_CHECK(root == ComputeFastMerkleRootFromBranch(leaves[2], branch, path));
+    }
+    BOOST_CHECK(ComputeFastMerkleRoot({}) == MerkleTree().GetHash());
+    for (int i = 1; i < 35; ++i) {
+        std::vector<uint256> leaves;
+        leaves.resize(i);
+        for (int j = 0; j < i; ++j) {
+            leaves.back().begin()[j/8] ^= ((char)1 << (j%8));
+        }
+        const uint256 root = ComputeFastMerkleRoot(leaves);
+        for (int j = 0; j < i; ++j) {
+            const auto branch = ComputeFastMerkleBranch(leaves, j);
+            BOOST_CHECK(ComputeFastMerkleRootFromBranch(leaves[j], branch.first, branch.second) == root);
+            std::vector<MerkleTree> subtrees(i);
+            for (int k = 0; k < i; ++k) {
+                if (k == j) {
+                    subtrees[k].m_verify.push_back(leaves[k]);
+                } else {
+                    subtrees[k].m_proof.m_skip.push_back(leaves[k]);
+                }
+            }
+            while (subtrees.size() > 1) {
+                std::vector<MerkleTree> other;
+                for (auto itr = subtrees.begin(); itr != subtrees.end(); ++itr) {
+                    auto itr2 = std::next(itr);
+                    if (itr2 != subtrees.end()) {
+                        other.emplace_back(*(itr++), *itr2);
+                    } else {
+                        other.emplace_back();
+                        swap(other.back(), *itr);
+                    }
+                }
+                swap(subtrees, other);
+            }
+            BOOST_CHECK(subtrees[0].m_verify.size() == 1);
+            bool invalid = false;
+            BOOST_CHECK(subtrees[0].GetHash(&invalid) == root);
+            BOOST_CHECK(!invalid);
+        }
     }
 }
 

--- a/src/test/merkle_tests.cpp
+++ b/src/test/merkle_tests.cpp
@@ -1182,7 +1182,7 @@ BOOST_AUTO_TEST_CASE(fast_merkle_branch)
       (CHashWriter(SER_GETHASH, PROTOCOL_VERSION) << 'c').GetHash(),
     };
     const uint256 root = ComputeFastMerkleRoot(leaves);
-    BOOST_CHECK(root == uint256S("0x9cde1ad752292baac9c86e91d0c0e506a3bc0e7f11fd449c8c54bbd3e46d91a1"));
+    BOOST_CHECK(root == uint256S("0x35d7dea3df173ecb85f59ebb88b2003be3c94b576576b12eb8d017f9fc33b289"));
     {
         std::vector<uint256> branch;
         uint32_t path;
@@ -1209,7 +1209,7 @@ BOOST_AUTO_TEST_CASE(fast_merkle_branch)
         std::tie(branch, path) = ComputeFastMerkleBranch(leaves, 2);
         BOOST_CHECK(path == 1);
         BOOST_CHECK(branch.size() == 1);
-        BOOST_CHECK(branch[0] == uint256S("0xc771140365578d348d7ffc6e04a102ecf3e2eea51177d38fac92f954aebdd1cd"));
+        BOOST_CHECK(branch[0] == uint256S("0xa6e8f6cfa607807d35da463f0599aa0d8032dda4e5635c806098a9ed332b6279"));
         BOOST_CHECK(root == ComputeFastMerkleRootFromBranch(leaves[2], branch, path));
     }
     BOOST_CHECK(ComputeFastMerkleRoot({}) == MerkleTree().GetHash());


### PR DESCRIPTION
This is a back-porting of the code for fast Merkle trees originally proposed for bitcoin as an implementation of BIP98: Fast Merkle Trees. Includes squashed fixes from @kallewoof pulled from the branch he maintained for inclusion in Bitcoin Core (which didn't happen).

The only substantive changes made in the back-port is throwing a `std::range_error` in `MerkleNodeReference::GetCode` and `MerkleNodeReference::SetCode` if the internal state of the reference is corrupted. Previously an assertion would have triggered in `GetCode` and `SetCode` would have silently done nothing.

The back-port changes are a separate commit that will be squashed before merging.