### PR TITLE
Add built-in Stratum v1 mining server for solo-mining

### DIFF
--- a/qa/rpc-tests/p2p-segwit.py
+++ b/qa/rpc-tests/p2p-segwit.py
@@ -439,6 +439,20 @@ class SegWitTest(FreicoinTestFramework):
         # Test the test -- witness serialization should be different
         assert(msg_witness_block(block).serialize() != msg_block(block).serialize())
 
+        # Tweak the extranonce (Coinbase's scriptSig).  This should
+        # not change the witness commitment, so the block remains
+        # valid.
+        old_scriptsig = block.vtx[0].vin[0].scriptSig
+        old_hash = block.vtx[0].sha256
+        old_commitment = block.vtx[-1].vout[-1].scriptPubKey
+        block.vtx[0].vin[0].scriptSig += bytes([4]) + (4 * b'\x00')
+        assert(block.vtx[0].vin[0].scriptSig != old_scriptsig)
+        block.vtx[0].rehash()
+        assert(block.vtx[0].sha256 != old_hash)
+        add_witness_commitment(block)
+        assert(block.vtx[-1].vout[-1].scriptPubKey == old_commitment)
+        block.solve()
+
         # This empty block should be valid.
         self.test_node.test_witness_block(block, accepted=True)
 
@@ -449,6 +463,20 @@ class SegWitTest(FreicoinTestFramework):
 
         # The commitment should have changed!
         assert(block_2.vtx[-1].vout[-1] != block.vtx[-1].vout[-1])
+
+        # Tweak the extranonce (Coinbase's nSequence).  This should
+        # not change the witness commitment, so the block remains
+        # valid (as this is before the coinbase-mtp soft-fork).
+        old_sequence = block_2.vtx[0].vin[0].nSequence
+        old_hash = block_2.vtx[0].sha256
+        old_commitment = block_2.vtx[-1].vout[-1].scriptPubKey
+        block_2.vtx[0].vin[0].nSequence ^= 0xffffffff
+        assert(block_2.vtx[0].vin[0].nSequence != old_sequence)
+        block_2.vtx[0].rehash()
+        assert(block_2.vtx[0].sha256 != old_hash)
+        add_witness_commitment(block_2, nonce=28)
+        assert(block_2.vtx[-1].vout[-1].scriptPubKey == old_commitment)
+        block_2.solve()
 
         # This should also be valid.
         self.test_node.test_witness_block(block_2, accepted=True)

--- a/qa/rpc-tests/test_framework/mininode.py
+++ b/qa/rpc-tests/test_framework/mininode.py
@@ -677,11 +677,20 @@ class CBlock(CBlockHeader):
         return self.get_merkle_root(hashes)
 
     def calc_witness_merkle_root(self):
-        # For witness root purposes, the hash of the coinbase does not include
-        # the coinbase witness, which is the witness nonce
-        if getattr(self.vtx[0], 'sha256', None) is None:
-            self.vtx[0].calc_sha256(False)
-        hashes = [ser_uint256(self.vtx[0].sha256)]
+        # For witness root purposes, the hash of the coinbase does not
+        # include the coinbase witness, which is the witness nonce,
+        # and it has both the coinbase string (scriptSig) and
+        # nSequence fields of the coinbase input zero'd out.
+        cb = self.vtx[0].serialize_without_witness()
+        pos = (4  # nVersion
+            +  1  # len(vin)
+            + 32  # vin[0].prevout.hash
+            +  4) # vin[0].prevout.n
+        if len(cb) >= (pos + 1):
+            pos2 = pos + 1 + cb[pos]
+            if len(cb) >= (pos2 + 4):
+                cb = cb[:pos] + b'\x00' + (4 * b'\x00') + cb[pos2+4:]
+        hashes = [hash256(cb)]
 
         for tx in self.vtx[1:-1]:
             # Calculate the hashes with witness data

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -141,6 +141,7 @@ FREICOIN_CORE_H = \
   script/sign.h \
   script/standard.h \
   script/ismine.h \
+  stratum.h \
   streams.h \
   support/allocators/secure.h \
   support/allocators/zeroafterfree.h \
@@ -206,6 +207,7 @@ libfreicoin_server_a_SOURCES = \
   rpc/server.cpp \
   script/sigcache.cpp \
   script/ismine.cpp \
+  stratum.cpp \
   timedata.cpp \
   torcontrol.cpp \
   txdb.cpp \

--- a/src/chainparamsbase.cpp
+++ b/src/chainparamsbase.cpp
@@ -47,6 +47,7 @@ public:
     CBaseMainParams()
     {
         nRPCPort = 8638;
+        nStratumPort = 9638;
     }
 };
 static CBaseMainParams mainParams;
@@ -60,6 +61,7 @@ public:
     CBaseTestNetParams()
     {
         nRPCPort = 18638;
+        nStratumPort = 19638;
         strDataDir = "testnet";
     }
 };
@@ -74,6 +76,7 @@ public:
     CBaseRegTestParams()
     {
         nRPCPort = 28638;
+        nStratumPort = 29638;
         strDataDir = "regtest";
     }
 };

--- a/src/chainparamsbase.h
+++ b/src/chainparamsbase.h
@@ -36,11 +36,13 @@ public:
 
     const std::string& DataDir() const { return strDataDir; }
     int RPCPort() const { return nRPCPort; }
+    int StratumPort() const { return nStratumPort; }
 
 protected:
     CBaseChainParams() {}
 
     int nRPCPort;
+    int nStratumPort;
     std::string strDataDir;
 };
 

--- a/src/consensus/merkle.cpp
+++ b/src/consensus/merkle.cpp
@@ -288,9 +288,27 @@ uint256 BlockWitnessMerkleRoot(const CBlock& block)
     std::vector<uint256> leaves;
     leaves.resize(block.vtx.size());
 
-    // The coinbase's witness contains the witness nonce, which cannot be
-    // included under the witness Merkle root.
-    leaves.front() = block.vtx.front().GetHash();
+    // For compatibility with the existing mining infrastructure,
+    // which expects that updating the coinbase's extranonce field has
+    // no impact on witness commitment in the block-final transaction,
+    // we zero out both the scriptSig and nSequence fields of the
+    // coinbase input.  As a result, either the 4-byte nSequence field
+    // (which has no consensus meaning) or the coinbase string can be
+    // updated by the hasher without having to recompute the witness
+    // commitment.  Using nSequence only would be preferred, since
+    // using the coinbase string adds space, but unfortunately the
+    // coinbase-mtp soft-fork has the side effect of forcing the
+    // coinbase's nSequence value to be set to SEQUENCE_FINAL, at
+    // least until the protocol cleanup hard-fork activates.  In the
+    // meantime, the scriptSig can be used.
+    CMutableTransaction cb(block.vtx.front());
+    if (!cb.vin.empty()) {
+        cb.vin[0].scriptSig = CScript();
+        cb.vin[0].nSequence = 0;
+    }
+    // The coinbase's witness contains the witness nonce, which cannot
+    // be included under the witness Merkle root.
+    leaves.front() = cb.GetHash();
 
     // The witness Merkle root is placed in the block-final transaction, but it
     // is a Merkle tree of all transactions, including itself.  To avoid this

--- a/src/consensus/merkle.cpp
+++ b/src/consensus/merkle.cpp
@@ -310,10 +310,10 @@ uint256 BlockWitnessMerkleRoot(const CBlock& block)
     // be included under the witness Merkle root.
     leaves.front() = cb.GetHash();
 
-    // The witness Merkle root is placed in the block-final transaction, but it
-    // is a Merkle tree of all transactions, including itself.  To avoid this
-    // impossibility, when computing the witness Merkle root the commitment is
-    // set to zero.
+    // The witness Merkle root is placed in the block-final
+    // transaction, but it is a Merkle tree of all transactions,
+    // including itself.  To avoid this impossibility, when computing
+    // the witness Merkle root the commitment is set to zero.
     CDataStream tx(SER_GETHASH, SERIALIZE_TRANSACTION_NO_WITNESS);
     tx << block.vtx.back();
 
@@ -324,11 +324,13 @@ uint256 BlockWitnessMerkleRoot(const CBlock& block)
         && tx[tx.size()-8-2] == 0x49  //    4 bytes for nLockTime
         && tx[tx.size()-8-1] == 0x48) //    4 bytes for lock_height
     {                                 //      (end of transaction)
-        // The witness commitment is set to 0.
+        // Set the witness commitment bytes to 0.
         std::fill_n(tx.end()-8-4-32-1, 33, 0);
     }
-    // The block-final transaction contains no witness data.
-    CHash256().Write((unsigned char*)&tx[0], tx.size()).Finalize(leaves.back().begin());
+    // The block-final transaction never contains any witness data.
+    CHash256()
+        .Write((unsigned char*)&tx[0], tx.size())
+        .Finalize(leaves.back().begin());
 
     for (size_t s = 1; s < block.vtx.size()-1; s++) {
         leaves[s] = block.vtx[s].GetWitnessHash();

--- a/src/httpserver.cpp
+++ b/src/httpserver.cpp
@@ -198,40 +198,37 @@ std::vector<HTTPPathHandler> pathHandlers;
 //! Bound listening sockets
 std::vector<evhttp_bound_socket *> boundSockets;
 
-/** Check if a network address is allowed to access the HTTP server */
-static bool ClientAllowed(const CNetAddr& netaddr)
+/** Check if a network address is allowed to access the server */
+bool ClientAllowed(const std::vector<CSubNet>& allowed_subnets, const CNetAddr& netaddr)
 {
     if (!netaddr.IsValid())
         return false;
-    BOOST_FOREACH (const CSubNet& subnet, rpc_allow_subnets)
+    BOOST_FOREACH (const CSubNet& subnet, allowed_subnets)
         if (subnet.Match(netaddr))
             return true;
     return false;
 }
 
 /** Initialize ACL list for HTTP server */
-static bool InitHTTPAllowList()
+bool InitSubnetAllowList(const std::string which, std::vector<CSubNet>& allowed_subnets)
 {
-    rpc_allow_subnets.clear();
-    rpc_allow_subnets.push_back(CSubNet("127.0.0.0/8")); // always allow IPv4 local subnet
-    rpc_allow_subnets.push_back(CSubNet("::1"));         // always allow IPv6 localhost
-    if (mapMultiArgs.count("-rpcallowip")) {
-        const std::vector<std::string>& vAllow = mapMultiArgs["-rpcallowip"];
+    allowed_subnets.clear();
+    allowed_subnets.push_back(CSubNet("127.0.0.0/8")); // always allow IPv4 local subnet
+    allowed_subnets.push_back(CSubNet("::1"));         // always allow IPv6 localhost
+    const std::string opt_allowip = "-" + which + "allowip";
+    if (mapMultiArgs.count(opt_allowip)) {
+        const std::vector<std::string>& vAllow = mapMultiArgs[opt_allowip];
         BOOST_FOREACH (std::string strAllow, vAllow) {
             CSubNet subnet(strAllow);
             if (!subnet.IsValid()) {
                 uiInterface.ThreadSafeMessageBox(
-                    strprintf("Invalid -rpcallowip subnet specification: %s. Valid are a single IP (e.g. 1.2.3.4), a network/netmask (e.g. 1.2.3.4/255.255.255.0) or a network/CIDR (e.g. 1.2.3.4/24).", strAllow),
+                    strprintf("Invalid %s subnet specification: %s. Valid are a single IP (e.g. 1.2.3.4), a network/netmask (e.g. 1.2.3.4/255.255.255.0) or a network/CIDR (e.g. 1.2.3.4/24).", opt_allowip, strAllow),
                     "", CClientUIInterface::MSG_ERROR);
                 return false;
             }
-            rpc_allow_subnets.push_back(subnet);
+            allowed_subnets.push_back(subnet);
         }
     }
-    std::string strAllowed;
-    BOOST_FOREACH (const CSubNet& subnet, rpc_allow_subnets)
-        strAllowed += subnet.ToString() + " ";
-    LogPrint("http", "Allowing HTTP connections from: %s\n", strAllowed);
     return true;
 }
 
@@ -265,7 +262,7 @@ static void http_request_cb(struct evhttp_request* req, void* arg)
              RequestMethodString(hreq->GetRequestMethod()), hreq->GetURI(), hreq->GetPeer().ToString());
 
     // Early address-based allow check
-    if (!ClientAllowed(hreq->GetPeer())) {
+    if (!ClientAllowed(rpc_allow_subnets, hreq->GetPeer())) {
         hreq->WriteReply(HTTP_FORBIDDEN);
         return;
     }
@@ -325,21 +322,21 @@ static void ThreadHTTP(struct event_base* base, struct evhttp* http)
     LogPrint("http", "Exited http event loop\n");
 }
 
-/** Bind HTTP server to specified addresses */
-static bool HTTPBindAddresses(struct evhttp* http)
+/** Determine what addresses to bind to */
+bool InitEndpointList(const std::string& which, int defaultPort, std::vector<std::pair<std::string, uint16_t> >& endpoints)
 {
-    int defaultPort = GetArg("-rpcport", BaseParams().RPCPort());
-    std::vector<std::pair<std::string, uint16_t> > endpoints;
+    endpoints.clear();
 
-    // Determine what addresses to bind to
-    if (!mapArgs.count("-rpcallowip")) { // Default to loopback if not allowing external IPs
+    const std::string opt_allowip = "-" + which + "allowip";
+    const std::string opt_bind = "-" + which + "bind";
+    if (!mapArgs.count(opt_allowip)) { // Default to loopback if not allowing external IPs
         endpoints.push_back(std::make_pair("::1", defaultPort));
         endpoints.push_back(std::make_pair("127.0.0.1", defaultPort));
-        if (mapArgs.count("-rpcbind")) {
-            LogPrintf("WARNING: option -rpcbind was ignored because -rpcallowip was not specified, refusing to allow everyone to connect\n");
+        if (mapArgs.count(opt_bind)) {
+            LogPrintf("WARNING: option %s was ignored because % was not specified, refusing to allow everyone to connect\n", opt_bind, opt_allowip);
         }
-    } else if (mapArgs.count("-rpcbind")) { // Specific bind address
-        const std::vector<std::string>& vbind = mapMultiArgs["-rpcbind"];
+    } else if (mapArgs.count(opt_bind)) { // Specific bind address
+        const std::vector<std::string>& vbind = mapMultiArgs[opt_bind];
         for (std::vector<std::string>::const_iterator i = vbind.begin(); i != vbind.end(); ++i) {
             int port = defaultPort;
             std::string host;
@@ -350,6 +347,19 @@ static bool HTTPBindAddresses(struct evhttp* http)
         endpoints.push_back(std::make_pair("::", defaultPort));
         endpoints.push_back(std::make_pair("0.0.0.0", defaultPort));
     }
+
+    return !endpoints.empty();
+}
+
+/** Bind HTTP server to specified addresses */
+static bool HTTPBindAddresses(struct evhttp* http)
+{
+    int defaultPort = GetArg("-rpcport", BaseParams().RPCPort());
+    std::vector<std::pair<std::string, uint16_t> > endpoints;
+
+    // Determine what addresses to bind to
+    if (!InitEndpointList("rpc", defaultPort, endpoints))
+        return false;
 
     // Bind addresses
     for (std::vector<std::pair<std::string, uint16_t> >::iterator i = endpoints.begin(); i != endpoints.end(); ++i) {
@@ -389,8 +399,13 @@ bool InitHTTPServer()
     struct evhttp* http = 0;
     struct event_base* base = 0;
 
-    if (!InitHTTPAllowList())
+    if (!InitSubnetAllowList("rpc", rpc_allow_subnets))
         return false;
+
+    std::string strAllowed;
+    BOOST_FOREACH (const CSubNet& subnet, rpc_allow_subnets)
+        strAllowed += subnet.ToString() + " ";
+    LogPrint("http", "Allowing HTTP connections from: %s\n", strAllowed);
 
     if (GetBoolArg("-rpcssl", false)) {
         uiInterface.ThreadSafeMessageBox(

--- a/src/httpserver.cpp
+++ b/src/httpserver.cpp
@@ -55,7 +55,7 @@
 static const size_t MAX_HEADERS_SIZE = 8192;
 
 /** HTTP request work item */
-class HTTPWorkItem : public HTTPClosure
+class HTTPWorkItem : public NetEventClosure
 {
 public:
     HTTPWorkItem(std::unique_ptr<HTTPRequest> req, const std::string &path, const HTTPRequestHandler& func):
@@ -192,7 +192,7 @@ struct evhttp* eventHTTP = 0;
 //! List of subnets to allow RPC connections from
 static std::vector<CSubNet> rpc_allow_subnets;
 //! Work queue for handling longer requests off the event loop thread
-static WorkQueue<HTTPClosure>* workQueue = 0;
+static WorkQueue<NetEventClosure>* workQueue = 0;
 //! Handlers for (sub)paths
 std::vector<HTTPPathHandler> pathHandlers;
 //! Bound listening sockets
@@ -365,7 +365,7 @@ static bool HTTPBindAddresses(struct evhttp* http)
 }
 
 /** Simple wrapper to set thread name and run work queue */
-static void HTTPWorkQueueRun(WorkQueue<HTTPClosure>* queue)
+static void HTTPWorkQueueRun(WorkQueue<NetEventClosure>* queue)
 {
     RenameThread("freicoin-httpworker");
     queue->Run();
@@ -445,7 +445,7 @@ bool InitHTTPServer()
     int workQueueDepth = std::max((long)GetArg("-rpcworkqueue", DEFAULT_HTTP_WORKQUEUE), 1L);
     LogPrintf("HTTP: creating work queue of depth %d\n", workQueueDepth);
 
-    workQueue = new WorkQueue<HTTPClosure>(workQueueDepth);
+    workQueue = new WorkQueue<NetEventClosure>(workQueueDepth);
     eventBase = base;
     eventHTTP = http;
     return true;

--- a/src/httpserver.h
+++ b/src/httpserver.h
@@ -130,11 +130,11 @@ public:
 
 /** Event handler closure.
  */
-class HTTPClosure
+class NetEventClosure
 {
 public:
     virtual void operator()() = 0;
-    virtual ~HTTPClosure() {}
+    virtual ~NetEventClosure() {}
 };
 
 /** Event class. This can be used either as an cross-thread trigger or as a timer.

--- a/src/httpserver.h
+++ b/src/httpserver.h
@@ -25,6 +25,8 @@
 #include <boost/scoped_ptr.hpp>
 #include <boost/function.hpp>
 
+#include "netbase.h"
+
 static const int DEFAULT_HTTP_THREADS=4;
 static const int DEFAULT_HTTP_WORKQUEUE=16;
 static const int DEFAULT_HTTP_SERVER_TIMEOUT=30;
@@ -33,6 +35,15 @@ struct evhttp_request;
 struct event_base;
 class CService;
 class HTTPRequest;
+
+/** Check if a network address is allowed to access the server */
+bool ClientAllowed(const std::vector<CSubNet>& allowed_subnets, const CNetAddr& netaddr);
+
+/** Initialize ACL list for HTTP server */
+bool InitSubnetAllowList(const std::string which, std::vector<CSubNet>& allowed_subnets);
+
+/** Determine what addresses to bind to. */
+bool InitEndpointList(const std::string& which, int defaultPort, std::vector<std::pair<std::string, uint16_t> >& endpoints);
 
 /** Initialize HTTP server.
  * Call this before RegisterHTTPHandler or EventBase().

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -488,6 +488,9 @@ std::string HelpMessage(HelpMessageMode mode)
         strUsage += HelpMessageOpt("-rpcservertimeout=<n>", strprintf("Timeout during HTTP requests (default: %d)", DEFAULT_HTTP_SERVER_TIMEOUT));
     }
 
+    strUsage += HelpMessageGroup(_("Stratum server options:"));
+    strUsage += HelpMessageOpt("-stratumport=<port>", strprintf(_("Listen for Stratum work requests on <port> (default: %u or testnet: %u)"), BaseParams(CBaseChainParams::MAIN).StratumPort(), BaseParams(CBaseChainParams::TESTNET).StratumPort()));
+
     return strUsage;
 }
 

--- a/src/stratum.cpp
+++ b/src/stratum.cpp
@@ -20,7 +20,10 @@
 #include "chainparams.h"
 #include "httpserver.h"
 #include "netbase.h"
+#include "rpc/server.h"
 #include "util.h"
+
+#include <univalue.h>
 
 #include <string>
 #include <vector>
@@ -62,6 +65,9 @@ static std::map<evconnlistener*, CService> bound_listeners;
 //! Active miners connected to us
 static std::map<bufferevent*, StratumClient> subscriptions;
 
+//! Mapping of stratum method names -> handlers
+static std::map<std::string, boost::function<UniValue(StratumClient&, const UniValue&)> > stratum_method_dispatch;
+
 /** Callback to read from a stratum connection. */
 static void stratum_read_cb(bufferevent *bev, void *ctx)
 {
@@ -72,7 +78,58 @@ static void stratum_read_cb(bufferevent *bev, void *ctx)
         return;
     }
     StratumClient& client = subscriptions[bev];
-    LogPrint("stratum", "Received data from stratum connection %s\n", client.GetPeer().ToString());
+    // Get links to the input and output buffers
+    evbuffer *input = bufferevent_get_input(bev);
+    evbuffer *output = bufferevent_get_output(bev);
+    // Process each line of input that we have received
+    char *cstr = 0;
+    size_t len = 0;
+    while (cstr = evbuffer_readln(input, &len, EVBUFFER_EOL_CRLF)) {
+        std::string line(cstr, len);
+        free(cstr);
+        LogPrint("stratum", "Received stratum request from %s : %s\n", client.GetPeer().ToString(), line);
+
+        JSONRequest jreq;
+        std::string reply;
+        try {
+            // Parse request
+            UniValue valRequest;
+            if (!valRequest.read(line)) {
+                // Not JSON; is this even a stratum miner?
+                throw JSONRPCError(RPC_PARSE_ERROR, "Parse error");
+            }
+            if (!valRequest.isObject()) {
+                // Not a JSON object; don't know what to do.
+                throw JSONRPCError(RPC_PARSE_ERROR, "Top-level object parse error");
+            }
+            if (valRequest.exists("result")) {
+                // JSON-RPC reply.  Ignore.
+                LogPrint("stratum", "Ignoring JSON-RPC response\n");
+                continue;
+            }
+            jreq.parse(valRequest);
+
+            // Dispatch to method handler
+            UniValue result = NullUniValue;
+            if (stratum_method_dispatch.count(jreq.strMethod)) {
+                result = stratum_method_dispatch[jreq.strMethod](client, jreq.params);
+            } else {
+                throw JSONRPCError(RPC_METHOD_NOT_FOUND, strprintf("Method '%s' not found", jreq.strMethod));
+            }
+
+            // Compose reply
+            reply = JSONRPCReply(result, NullUniValue, jreq.id);
+        } catch (const UniValue& objError) {
+            reply = JSONRPCReply(NullUniValue, objError, jreq.id);
+        } catch (const std::exception& e) {
+            reply = JSONRPCReply(NullUniValue, JSONRPCError(RPC_PARSE_ERROR, e.what()), jreq.id);
+        }
+
+        LogPrint("stratum", "Sending stratum response to %s : %s", client.GetPeer().ToString(), reply);
+        if (evbuffer_add(output, reply.data(), reply.size())) {
+            LogPrint("stratum", "Sending stratum response failed. (Reason: %d, '%s')\n", errno, evutil_socket_error_to_string(errno));
+        }
+    }
 }
 
 /** Callback to handle unrecoverable errors in a stratum link. */

--- a/src/stratum.cpp
+++ b/src/stratum.cpp
@@ -32,6 +32,7 @@
 #include "utilstrencodings.h"
 #include "serialize.h"
 #include "streams.h"
+#include "sync.h"
 #include "txmempool.h"
 
 #include <univalue.h>
@@ -124,6 +125,9 @@ void UpdateSegwitCommitment(const StratumWork& current_work, CMutableTransaction
     cb_branch = BlockMerkleBranch(block2, 0);
 }
 
+//! Critical seciton guarding access to any of the stratum global state
+static CCriticalSection cs_stratum;
+
 //! List of subnets to allow stratum connections from
 static std::vector<CSubNet> stratum_allow_subnets;
 
@@ -138,6 +142,9 @@ static std::map<std::string, boost::function<UniValue(StratumClient&, const UniV
 
 //! A mapping of job_id -> work templates
 static std::map<uint256, StratumWork> work_templates;
+
+//! A thread to watch for new blocks and send mining notifications
+static boost::thread block_watcher_thread;
 
 std::string HexInt4(uint32_t val)
 {
@@ -509,6 +516,7 @@ UniValue stratum_mining_submit(StratumClient& client, const UniValue& params)
 static void stratum_read_cb(bufferevent *bev, void *ctx)
 {
     evconnlistener *listener = (evconnlistener*)ctx;
+    LOCK(cs_stratum);
     // Lookup the client record for this connection
     if (!subscriptions.count(bev)) {
         LogPrint("stratum", "Received read notification for unknown stratum connection 0x%x\n", (size_t)bev);
@@ -592,6 +600,7 @@ static void stratum_read_cb(bufferevent *bev, void *ctx)
 static void stratum_event_cb(bufferevent *bev, short what, void *ctx)
 {
     evconnlistener *listener = (evconnlistener*)ctx;
+    LOCK(cs_stratum);
     // Fetch the return address for this connection, for the debug log.
     std::string from("UNKNOWN");
     if (!subscriptions.count(bev)) {
@@ -622,6 +631,7 @@ static void stratum_event_cb(bufferevent *bev, short what, void *ctx)
 /** Callback to accept a stratum connection. */
 static void stratum_accept_conn_cb(evconnlistener *listener, evutil_socket_t fd, sockaddr *address, int socklen, void *ctx)
 {
+    LOCK(cs_stratum);
     // Parse the return address
     CService from;
     from.SetSockAddr(address);
@@ -686,9 +696,63 @@ bool StratumBindAddresses(event_base* base)
     return !bound_listeners.empty();
 }
 
+/** Watches for new blocks and send updated work to miners. */
+static bool g_shutdown = false;
+void BlockWatcher()
+{
+    boost::unique_lock<boost::mutex> lock(csBestBlock);
+    boost::system_time checktxtime = boost::get_system_time();
+    unsigned int txns_updated_last = 0;
+    while (true) {
+        checktxtime += boost::posix_time::seconds(15);
+        if (!cvBlockChange.timed_wait(lock, checktxtime)) {
+            // Timeout: Check to see if mempool was updated.
+            unsigned int txns_updated_next = mempool.GetTransactionsUpdated();
+            if (txns_updated_last == txns_updated_next)
+                continue;
+            txns_updated_last = txns_updated_next;
+        }
+
+        LOCK(cs_stratum);
+
+        if (g_shutdown) {
+            break;
+        }
+
+        // Either new block, or updated transactions.  Either way,
+        // send updated work to miners.
+        typedef std::pair<bufferevent*, StratumClient> subscription_type;
+        BOOST_FOREACH (subscription_type subscription, subscriptions) {
+            bufferevent* bev = subscription.first;
+            evbuffer *output = bufferevent_get_output(bev);
+            StratumClient& client = subscription.second;
+            // Ignore clients that aren't authorized yet.
+            if (!client.m_authorized) {
+                continue;
+            }
+            // Get new work
+            std::string data;
+            try {
+                data = GetWorkUnit(client);
+            } catch (...) {
+                // Some sort of error.  Ignore.
+                LogPrint("stratum", "Error generating updated work for stratum client\n");
+                continue;
+            }
+            // Send the new work to the client
+            LogPrint("stratum", "Sending updated stratum work unit to %s : %s", client.GetPeer().ToString(), data);
+            if (evbuffer_add(output, data.data(), data.size())) {
+                LogPrint("stratum", "Sending stratum work unit failed. (Reason: %d, '%s')\n", errno, evutil_socket_error_to_string(errno));
+            }
+        }
+    }
+}
+
 /** Configure the stratum server */
 bool InitStratumServer()
 {
+    LOCK(cs_stratum);
+
     if (!InitSubnetAllowList("stratum", stratum_allow_subnets)) {
         LogPrint("stratum", "Unable to bind stratum server to an endpoint.\n");
         return false;
@@ -716,22 +780,30 @@ bool InitStratumServer()
     stratum_method_dispatch["mining.authorize"] = stratum_mining_authorize;
     stratum_method_dispatch["mining.submit"]    = stratum_mining_submit;
 
+    // Start thread to wait for block notifications and send updated
+    // work to miners.
+    block_watcher_thread = boost::thread(BlockWatcher);
+
     return true;
 }
 
 /** Interrupt the stratum server connections */
 void InterruptStratumServer()
 {
+    LOCK(cs_stratum);
     // Stop listening for connections on stratum sockets
     for (auto binding : bound_listeners) {
         LogPrint("stratum", "Interrupting stratum service on %s\n", binding.second.ToString());
         evconnlistener_disable(binding.first);
     }
+    // Tell the block watching thread to stop
+    g_shutdown = true;
 }
 
 /** Cleanup stratum server network connections and free resources. */
 void StopStratumServer()
 {
+    LOCK(cs_stratum);
     /* Tear-down active connections. */
     for (auto subscription : subscriptions) {
         LogPrint("stratum", "Closing stratum server connection to %s due to process termination\n", subscription.second.GetPeer().ToString());

--- a/src/stratum.cpp
+++ b/src/stratum.cpp
@@ -1,0 +1,135 @@
+// Copyright (c) 2020 The Freicoin Developers
+//
+// This program is free software: you can redistribute it and/or
+// modify it under the conjunctive terms of BOTH version 3 of the GNU
+// Affero General Public License as published by the Free Software
+// Foundation AND the MIT/X11 software license.
+//
+// This program is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Affero General Public License and the MIT/X11 software license for
+// more details.
+//
+// You should have received a copy of both licenses along with this
+// program.  If not, see <https://www.gnu.org/licenses/> and
+// <http://www.opensource.org/licenses/mit-license.php>
+
+#include "stratum.h"
+
+#include "chainparams.h"
+#include "httpserver.h"
+#include "netbase.h"
+#include "util.h"
+
+#include <string>
+#include <vector>
+
+#include <event2/event.h>
+#include <event2/listener.h>
+#include <event2/bufferevent.h>
+#include <event2/buffer.h>
+
+#include <errno.h>
+#include <arpa/inet.h>
+#include <netinet/tcp.h>
+
+//! List of subnets to allow stratum connections from
+static std::vector<CSubNet> stratum_allow_subnets;
+
+//! Bound stratum listening sockets
+static std::map<evconnlistener*, CService> bound_listeners;
+
+/** Callback to accept a stratum connection. */
+static void stratum_accept_conn_cb(evconnlistener *listener, evutil_socket_t fd, sockaddr *address, int socklen, void *ctx)
+{
+    CService service;
+    service.SetSockAddr(address);
+    LogPrint("stratum", "Accepted stratum connection from %s\n", service.ToString());
+}
+
+/** Setup the stratum connection listening services */
+bool StratumBindAddresses(event_base* base)
+{
+    int defaultPort = GetArg("-stratumport", BaseParams().StratumPort());
+    std::vector<std::pair<std::string, uint16_t> > endpoints;
+
+    // Determine what addresses to bind to
+    if (!InitEndpointList("stratum", defaultPort, endpoints))
+        return false;
+
+    // Bind each addresses
+    for (auto endpoint : endpoints) {
+        LogPrint("stratum", "Binding stratum on address %s port %i\n", endpoint.first, endpoint.second);
+        // Use CService to translate string -> sockaddr
+        CService socket(CNetAddr(endpoint.first), endpoint.second);
+        union {
+            sockaddr     ipv4;
+            sockaddr_in6 ipv6;
+        } addr;
+        socklen_t len = sizeof(addr);
+        socket.GetSockAddr((sockaddr*)&addr, &len);
+        // Setup an event listener for the endpoint
+        evconnlistener *listener = evconnlistener_new_bind(base, stratum_accept_conn_cb, NULL, LEV_OPT_CLOSE_ON_FREE|LEV_OPT_REUSEABLE, -1, (sockaddr*)&addr, len);
+        // Only record successful binds
+        if (listener) {
+            bound_listeners[listener] = socket;
+        } else {
+            LogPrintf("Binding stratum on address %s port %i failed. (Reason: %d, '%s')\n", endpoint.first, endpoint.second, errno, evutil_socket_error_to_string(errno));
+        }
+    }
+
+    return !bound_listeners.empty();
+}
+
+/** Configure the stratum server */
+bool InitStratumServer()
+{
+    if (!InitSubnetAllowList("stratum", stratum_allow_subnets)) {
+        LogPrint("stratum", "Unable to bind stratum server to an endpoint.\n");
+        return false;
+    }
+
+    std::string strAllowed;
+    for (auto subnet : stratum_allow_subnets) {
+        strAllowed += subnet.ToString() + " ";
+    }
+    LogPrint("stratum", "Allowing stratum connections from: %s\n", strAllowed);
+
+    event_base* base = EventBase();
+    if (!base) {
+        LogPrint("stratum", "No event_base object, cannot setup stratum server.\n");
+        return false;
+    }
+
+    if (!StratumBindAddresses(base)) {
+        LogPrintf("Unable to bind any endpoint for stratum server\n");
+    } else {
+        LogPrint("stratum", "Initialized stratum server\n");
+    }
+
+    return true;
+}
+
+/** Interrupt the stratum server connections */
+void InterruptStratumServer()
+{
+    // Stop listening for connections on stratum sockets
+    for (auto binding : bound_listeners) {
+        LogPrint("stratum", "Interrupting stratum service on %s\n", binding.second.ToString());
+        evconnlistener_disable(binding.first);
+    }
+}
+
+/** Cleanup stratum server network connections and free resources. */
+void StopStratumServer()
+{
+    /* Un-bind our listeners from their network interfaces. */
+    for (auto binding : bound_listeners) {
+        LogPrint("stratum", "Removing stratum server binding on %s\n", binding.second.ToString());
+        evconnlistener_free(binding.first);
+    }
+    bound_listeners.clear();
+}
+
+// End of File

--- a/src/stratum.cpp
+++ b/src/stratum.cpp
@@ -31,8 +31,27 @@
 #include <event2/buffer.h>
 
 #include <errno.h>
+#ifdef WIN32
+#include <winsock2.h>
+#else
 #include <arpa/inet.h>
 #include <netinet/tcp.h>
+#include <sys/socket.h>
+#endif
+
+struct StratumClient
+{
+    evconnlistener* m_listener;
+    evutil_socket_t m_socket;
+    bufferevent* m_bev;
+    CService m_from;
+
+    CService GetPeer() const
+      { return m_from; }
+
+    StratumClient() : m_listener(0), m_socket(0), m_bev(0) { }
+    StratumClient(evconnlistener* listener, evutil_socket_t socket, bufferevent* bev, CService from) : m_listener(listener), m_socket(socket), m_bev(bev), m_from(from) { }
+};
 
 //! List of subnets to allow stratum connections from
 static std::vector<CSubNet> stratum_allow_subnets;
@@ -40,12 +59,84 @@ static std::vector<CSubNet> stratum_allow_subnets;
 //! Bound stratum listening sockets
 static std::map<evconnlistener*, CService> bound_listeners;
 
+//! Active miners connected to us
+static std::map<bufferevent*, StratumClient> subscriptions;
+
+/** Callback to read from a stratum connection. */
+static void stratum_read_cb(bufferevent *bev, void *ctx)
+{
+    evconnlistener *listener = (evconnlistener*)ctx;
+    // Lookup the client record for this connection
+    if (!subscriptions.count(bev)) {
+        LogPrint("stratum", "Received read notification for unknown stratum connection 0x%x\n", (size_t)bev);
+        return;
+    }
+    StratumClient& client = subscriptions[bev];
+    LogPrint("stratum", "Received data from stratum connection %s\n", client.GetPeer().ToString());
+}
+
+/** Callback to handle unrecoverable errors in a stratum link. */
+static void stratum_event_cb(bufferevent *bev, short what, void *ctx)
+{
+    evconnlistener *listener = (evconnlistener*)ctx;
+    // Fetch the return address for this connection, for the debug log.
+    std::string from("UNKNOWN");
+    if (!subscriptions.count(bev)) {
+        LogPrint("stratum", "Received event notification for unknown stratum connection 0x%x\n", (size_t)bev);
+        return;
+    } else {
+        from = subscriptions[bev].GetPeer().ToString();
+    }
+    // Report the reason why we are closing the connection.
+    if (what & BEV_EVENT_ERROR) {
+        LogPrint("stratum", "Error detected on stratum connection from %s\n", from);
+    }
+    if (what & BEV_EVENT_EOF) {
+        LogPrint("stratum", "Remote disconnect received on stratum connection from %s\n", from);
+    }
+    // Remove the connection from our records, and tell libevent to
+    // disconnect and free its resources.
+    if (what & (BEV_EVENT_EOF | BEV_EVENT_ERROR)) {
+        LogPrint("stratum", "Closing stratum connection from %s\n", from);
+        subscriptions.erase(bev);
+        if (bev) {
+            bufferevent_free(bev);
+            bev = NULL;
+        }
+    }
+}
+
 /** Callback to accept a stratum connection. */
 static void stratum_accept_conn_cb(evconnlistener *listener, evutil_socket_t fd, sockaddr *address, int socklen, void *ctx)
 {
-    CService service;
-    service.SetSockAddr(address);
-    LogPrint("stratum", "Accepted stratum connection from %s\n", service.ToString());
+    // Parse the return address
+    CService from;
+    from.SetSockAddr(address);
+    // Early address-based allow check
+    if (!ClientAllowed(stratum_allow_subnets, from)) {
+        evconnlistener_free(listener);
+        LogPrint("stratum", "Rejected connection from disallowed subnet: %s\n", from.ToString());
+        return;
+    }
+    // Should be the same as EventBase(), but let's get it the
+    // official way.
+    event_base *base = evconnlistener_get_base(listener);
+    // Create a buffer for sending/receiving from this connection.
+    bufferevent *bev = bufferevent_socket_new(base, fd, BEV_OPT_CLOSE_ON_FREE);
+    // Disable Nagle's algorithm, so that TCP packets are sent
+    // immediately, even if it results in a small packet.
+    int one = 1;
+    setsockopt(fd, IPPROTO_TCP, TCP_NODELAY, (char*)&one, sizeof(one));
+    // Setup the read and event callbacks to handle receiving requests
+    // from the miner and error handling.  A write callback isn't
+    // needed because we're not sending enough data to fill buffers.
+    bufferevent_setcb(bev, stratum_read_cb, NULL, stratum_event_cb, (void*)listener);
+    // Enable bidirectional communication on the connection.
+    bufferevent_enable(bev, EV_READ|EV_WRITE);
+    // Record the connection state
+    subscriptions[bev] = StratumClient(listener, fd, bev, from);
+    // Log the connection.
+    LogPrint("stratum", "Accepted stratum connection from %s\n", from.ToString());
 }
 
 /** Setup the stratum connection listening services */
@@ -124,6 +215,12 @@ void InterruptStratumServer()
 /** Cleanup stratum server network connections and free resources. */
 void StopStratumServer()
 {
+    /* Tear-down active connections. */
+    for (auto subscription : subscriptions) {
+        LogPrint("stratum", "Closing stratum server connection to %s due to process termination\n", subscription.second.GetPeer().ToString());
+        bufferevent_free(subscription.first);
+    }
+    subscriptions.clear();
     /* Un-bind our listeners from their network interfaces. */
     for (auto binding : bound_listeners) {
         LogPrint("stratum", "Removing stratum server binding on %s\n", binding.second.ToString());

--- a/src/stratum.h
+++ b/src/stratum.h
@@ -1,0 +1,39 @@
+// Copyright (c) 2020 The Freicoin Developers
+//
+// This program is free software: you can redistribute it and/or
+// modify it under the conjunctive terms of BOTH version 3 of the GNU
+// Affero General Public License as published by the Free Software
+// Foundation AND the MIT/X11 software license.
+//
+// This program is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Affero General Public License and the MIT/X11 software license for
+// more details.
+//
+// You should have received a copy of both licenses along with this
+// program.  If not, see <https://www.gnu.org/licenses/> and
+// <http://www.opensource.org/licenses/mit-license.php>
+
+#ifndef FREICOIN_STRATUM_H
+#define FREICOIN_STRATUM_H
+
+#include "netbase.h"
+
+#include <event2/event.h>
+
+/** Setup the stratum connection listening services. */
+bool StratumBindAddresses(event_base* base);
+
+/** Configure the stratum server. */
+bool InitStratumServer();
+
+/** Interrupt the stratum server connections. */
+void InterruptStratumServer();
+
+/** Cleanup stratum server network connections and free resources. */
+void StopStratumServer();
+
+#endif // FREICOIN_STRATUM_H
+
+// End of File


### PR DESCRIPTION
Rather than individually support a variety of server or proxy back-ends, we should expose an ASICBoost-compatible Stratum v1 TCP server API endpoint, so that any Freicoin/Tradecraft full-node can be used to drive hashing hardware without requiring any additional software (other than the driver for the mining hardware itself).

This pull request tracks the initial implementation of a stratum v1 mining service, which will be considered feature complete when it is able to serve work to both [cpuminer](https://github.com/pooler/cpuminer) (for testing purposes) and [bmminer](https://github.com/jameshilliard/bmminer) (which drives a large percentage of the existing network hash power). Other issues and pull requests should be used to track additional features and extensions, or tweaks required for getting other mining backends to work.