### PR TITLE
Mask Coinbase's scriptSig and nSequence out of witness commitment

### DIFF
--- a/qa/rpc-tests/p2p-segwit.py
+++ b/qa/rpc-tests/p2p-segwit.py
@@ -439,6 +439,20 @@ class SegWitTest(FreicoinTestFramework):
         # Test the test -- witness serialization should be different
         assert(msg_witness_block(block).serialize() != msg_block(block).serialize())
 
+        # Tweak the extranonce (Coinbase's scriptSig).  This should
+        # not change the witness commitment, so the block remains
+        # valid.
+        old_scriptsig = block.vtx[0].vin[0].scriptSig
+        old_hash = block.vtx[0].sha256
+        old_commitment = block.vtx[-1].vout[-1].scriptPubKey
+        block.vtx[0].vin[0].scriptSig += bytes([4]) + (4 * b'\x00')
+        assert(block.vtx[0].vin[0].scriptSig != old_scriptsig)
+        block.vtx[0].rehash()
+        assert(block.vtx[0].sha256 != old_hash)
+        add_witness_commitment(block)
+        assert(block.vtx[-1].vout[-1].scriptPubKey == old_commitment)
+        block.solve()
+
         # This empty block should be valid.
         self.test_node.test_witness_block(block, accepted=True)
 
@@ -449,6 +463,20 @@ class SegWitTest(FreicoinTestFramework):
 
         # The commitment should have changed!
         assert(block_2.vtx[-1].vout[-1] != block.vtx[-1].vout[-1])
+
+        # Tweak the extranonce (Coinbase's nSequence).  This should
+        # not change the witness commitment, so the block remains
+        # valid (as this is before the coinbase-mtp soft-fork).
+        old_sequence = block_2.vtx[0].vin[0].nSequence
+        old_hash = block_2.vtx[0].sha256
+        old_commitment = block_2.vtx[-1].vout[-1].scriptPubKey
+        block_2.vtx[0].vin[0].nSequence ^= 0xffffffff
+        assert(block_2.vtx[0].vin[0].nSequence != old_sequence)
+        block_2.vtx[0].rehash()
+        assert(block_2.vtx[0].sha256 != old_hash)
+        add_witness_commitment(block_2, nonce=28)
+        assert(block_2.vtx[-1].vout[-1].scriptPubKey == old_commitment)
+        block_2.solve()
 
         # This should also be valid.
         self.test_node.test_witness_block(block_2, accepted=True)

--- a/qa/rpc-tests/test_framework/mininode.py
+++ b/qa/rpc-tests/test_framework/mininode.py
@@ -677,11 +677,20 @@ class CBlock(CBlockHeader):
         return self.get_merkle_root(hashes)
 
     def calc_witness_merkle_root(self):
-        # For witness root purposes, the hash of the coinbase does not include
-        # the coinbase witness, which is the witness nonce
-        if getattr(self.vtx[0], 'sha256', None) is None:
-            self.vtx[0].calc_sha256(False)
-        hashes = [ser_uint256(self.vtx[0].sha256)]
+        # For witness root purposes, the hash of the coinbase does not
+        # include the coinbase witness, which is the witness nonce,
+        # and it has both the coinbase string (scriptSig) and
+        # nSequence fields of the coinbase input zero'd out.
+        cb = self.vtx[0].serialize_without_witness()
+        pos = (4  # nVersion
+            +  1  # len(vin)
+            + 32  # vin[0].prevout.hash
+            +  4) # vin[0].prevout.n
+        if len(cb) >= (pos + 1):
+            pos2 = pos + 1 + cb[pos]
+            if len(cb) >= (pos2 + 4):
+                cb = cb[:pos] + b'\x00' + (4 * b'\x00') + cb[pos2+4:]
+        hashes = [hash256(cb)]
 
         for tx in self.vtx[1:-1]:
             # Calculate the hashes with witness data

--- a/src/consensus/merkle.cpp
+++ b/src/consensus/merkle.cpp
@@ -288,9 +288,27 @@ uint256 BlockWitnessMerkleRoot(const CBlock& block)
     std::vector<uint256> leaves;
     leaves.resize(block.vtx.size());
 
-    // The coinbase's witness contains the witness nonce, which cannot be
-    // included under the witness Merkle root.
-    leaves.front() = block.vtx.front().GetHash();
+    // For compatibility with the existing mining infrastructure,
+    // which expects that updating the coinbase's extranonce field has
+    // no impact on witness commitment in the block-final transaction,
+    // we zero out both the scriptSig and nSequence fields of the
+    // coinbase input.  As a result, either the 4-byte nSequence field
+    // (which has no consensus meaning) or the coinbase string can be
+    // updated by the hasher without having to recompute the witness
+    // commitment.  Using nSequence only would be preferred, since
+    // using the coinbase string adds space, but unfortunately the
+    // coinbase-mtp soft-fork has the side effect of forcing the
+    // coinbase's nSequence value to be set to SEQUENCE_FINAL, at
+    // least until the protocol cleanup hard-fork activates.  In the
+    // meantime, the scriptSig can be used.
+    CMutableTransaction cb(block.vtx.front());
+    if (!cb.vin.empty()) {
+        cb.vin[0].scriptSig = CScript();
+        cb.vin[0].nSequence = 0;
+    }
+    // The coinbase's witness contains the witness nonce, which cannot
+    // be included under the witness Merkle root.
+    leaves.front() = cb.GetHash();
 
     // The witness Merkle root is placed in the block-final transaction, but it
     // is a Merkle tree of all transactions, including itself.  To avoid this


### PR DESCRIPTION
The Stratum mining protocol requires some number of bytes of the coinbase, typically 4 bytes, to be under the miner's control.  And existing mining software is unaware of block-final transactions or our witness commitment mechanism.  To maintain compatibility with this critical, already deployed infrastructure, the nSequence field of the coinbase transaction is zero'd when calculating the witness commitment hash.  This allows these 4 bytes to be set by the miner without altering the witness hash, which would require re-calculating the transaction Merkle tree.