### PR TITLE
[Warn] Do not warn about unknown version bits set.

### DIFF
--- a/qa/pull-tester/rpc-tests.py
+++ b/qa/pull-tester/rpc-tests.py
@@ -151,7 +151,9 @@ testScripts = [
     'invalidblockrequest.py',
     'invalidtxrequest.py',
     'abandonconflict.py --bitcoin-mode',
-    'p2p-versionbits-warning.py',
+    # Disabled as the alertnotify logic has been removed until it is updated
+    # to handle overt ASICBoost version-rolling:
+#    'p2p-versionbits-warning.py',
     'p2p-segwit.py --bitcoin-mode',
     'segwit.py --bitcoin-mode',
     'importprunedfunds.py',
@@ -173,7 +175,9 @@ testScriptsExt = [
     'getblocktemplate_proposals.py',
     'txn_doublespend.py --bitcoin-mode',
     'txn_clone.py --mineblock --bitcoin-mode',
-    'forknotify.py',
+    # Disabled as the alertnotify logic has been removed until it is updated
+    # to handle overt ASICBoost version-rolling:
+#    'forknotify.py',
     'invalidateblock.py',
     'rpcbind_test.py',
     'smartfees.py --bitcoin-mode',

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2960,15 +2960,6 @@ void static UpdateTip(CBlockIndex *pindexNew, const CChainParams& chainParams) {
         }
         if (nUpgraded > 0)
             warningMessages.push_back(strprintf("%d of last 100 blocks have unexpected version", nUpgraded));
-        if (nUpgraded > 100/2)
-        {
-            // strMiscWarning is read by GetWarnings(), called by Qt and the JSON-RPC code to warn the user:
-            strMiscWarning = _("Warning: Unknown block versions being mined! It's possible unknown rules are in effect");
-            if (!fWarned) {
-                AlertNotify(strMiscWarning);
-                fWarned = true;
-            }
-        }
     }
     LogPrintf("%s: new best=%s height=%d version=0x%08x log2_work=%.8g tx=%lu date='%s' progress=%f cache=%.1fMiB(%utx)", __func__,
       chainActive.Tip()->GetBlockHash().ToString(), chainActive.Height(), chainActive.Tip()->nVersion,


### PR DESCRIPTION
Having unspecified version bit flags set is normal now that the industry has transitioned to version-rolling mining hardware. The upstream 0.13 release of bitcoin raises a warning if more than 50 of the last 100 blocks show unrecognized version numbers. In the current network, this is almost always the case. This PR disables the warning, and disables the RPC tests which check for the warning.