### PR TITLE
[Stratum] Disable server by default, and fix RPC tests.

### DIFF
--- a/qa/rpc-tests/test_framework/util.py
+++ b/qa/rpc-tests/test_framework/util.py
@@ -116,6 +116,9 @@ def p2p_port(n):
 def rpc_port(n):
     return PORT_MIN + PORT_RANGE + n + (MAX_NODES * PortSeed.n) % (PORT_RANGE - 1 - MAX_NODES)
 
+def stratum_port(n):
+    return PORT_MIN + (2 * PORT_RANGE) + n + (MAX_NODES * PortSeed.n) % (PORT_RANGE - 1 - MAX_NODES)
+
 def check_json_precision():
     """Make sure json library being used does not lose precision converting FRC values"""
     n = Decimal("20000000.00000003")
@@ -179,6 +182,7 @@ def initialize_datadir(dirname, n, bitcoinmode=False):
         f.write("rpcpassword=" + rpc_p + "\n")
         f.write("port="+str(p2p_port(n))+"\n")
         f.write("rpcport="+str(rpc_port(n))+"\n")
+        f.write("stratumport="+str(stratum_port(n))+"\n")
         f.write("listenonion=0\n")
     return datadir
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -493,6 +493,7 @@ std::string HelpMessage(HelpMessageMode mode)
     }
 
     strUsage += HelpMessageGroup(_("Stratum server options:"));
+    strUsage += HelpMessageOpt("-stratum", _("Enable stratum server (default: off)"));
     strUsage += HelpMessageOpt("-stratumbind=<addr>", _("Bind to given address to listen for Stratum work requests. Use [host]:port notation for IPv6. This option can be specified multiple times (default: bind to all interfaces)"));
     strUsage += HelpMessageOpt("-stratumport=<port>", strprintf(_("Listen for Stratum work requests on <port> (default: %u or testnet: %u)"), BaseParams(CBaseChainParams::MAIN).StratumPort(), BaseParams(CBaseChainParams::TESTNET).StratumPort()));
     strUsage += HelpMessageOpt("-stratumallowip=<ip>", _("Allow Stratum work requests from specified source. Valid for <ip> are a single IP (e.g. 1.2.3.4), a network/netmask (e.g. 1.2.3.4/255.255.255.0) or a network/CIDR (e.g. 1.2.3.4/24). This option can be specified multiple times"));
@@ -691,7 +692,7 @@ bool AppInitServers(boost::thread_group& threadGroup)
     RPCServer::OnPreCommand(&OnRPCPreCommand);
     if (!InitHTTPServer())
         return false;
-    if (!InitStratumServer())
+    if (GetBoolArg("-stratum", DEFAULT_STRATUM_ENABLE) && !InitStratumServer())
         return false;
     if (!StartRPC())
         return false;

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -81,6 +81,7 @@ using namespace std;
 bool fFeeEstimatesInitialized = false;
 static const bool DEFAULT_PROXYRANDOMIZE = true;
 static const bool DEFAULT_REST_ENABLE = false;
+static const bool DEFAULT_STRATUM_ENABLE = false;
 static const bool DEFAULT_DISABLE_SAFEMODE = false;
 static const bool DEFAULT_STOPAFTERBLOCKIMPORT = false;
 


### PR DESCRIPTION
For security reasons, it is preferable to have the stratum server disabled by default.  It's just one less potential attack interface.  This also fixes the rpcbind RPC test.  While we're at it, this PR also fixes the stratum port assignment for RPC tests, so that multiple nodes don't conflict over the same port.  Not that this matters, since there aren't any stratum RPC tests yet and it is disabled by default, but it'll prevent a potential bug once we do write some stratum tests.