### PR TITLE
Fix block-final tx related database corruption on v13

### DIFF
--- a/qa/pull-tester/rpc-tests.py
+++ b/qa/pull-tester/rpc-tests.py
@@ -187,8 +187,7 @@ testScriptsExt = [
     'maxuploadtarget.py',
     'replace-by-fee.py --bitcoin-mode',
     'p2p-feefilter.py',
-    # Disabled due to block-final reorg bug:
-#    'pruning.py --bitcoin-mode', # leave pruning last as it takes a REALLY long time
+    'pruning.py --bitcoin-mode', # leave pruning last as it takes a REALLY long time
 ]
 
 

--- a/src/coins.cpp
+++ b/src/coins.cpp
@@ -172,10 +172,10 @@ bool CCoinsViewCache::HaveCoinsInCache(const uint256 &txid) const {
 }
 
 uint256 CCoinsViewCache::GetBestBlock() const {
-    if (hashBlock.IsNull()) {
+    if (!hashBlock) {
         hashBlock = base->GetBestBlock();
     }
-    return hashBlock;
+    return *hashBlock;
 }
 
 void CCoinsViewCache::SetBestBlock(const uint256 &hashBlockIn) {
@@ -183,10 +183,10 @@ void CCoinsViewCache::SetBestBlock(const uint256 &hashBlockIn) {
 }
 
 uint256 CCoinsViewCache::GetFinalTx() const {
-    if (hashFinalTx.IsNull()) {
+    if (!hashFinalTx) {
         hashFinalTx = base->GetFinalTx();
     }
-    return hashFinalTx;
+    return *hashFinalTx;
 }
 
 void CCoinsViewCache::SetFinalTx(const uint256 &hashFinalTxIn) {
@@ -240,7 +240,7 @@ bool CCoinsViewCache::BatchWrite(CCoinsMap &mapCoins, const uint256 &hashBlockIn
 }
 
 bool CCoinsViewCache::Flush() {
-    bool fOk = base->BatchWrite(cacheCoins, hashBlock, hashFinalTx);
+    bool fOk = base->BatchWrite(cacheCoins, GetBestBlock(), GetFinalTx());
     cacheCoins.clear();
     cachedCoinsUsage = 0;
     return fOk;

--- a/src/coins.h
+++ b/src/coins.h
@@ -31,6 +31,7 @@
 #include <stdint.h>
 
 #include <boost/foreach.hpp>
+#include <boost/optional.hpp>
 #include <boost/unordered_map.hpp>
 
 /** 
@@ -436,8 +437,8 @@ protected:
      * Make mutable so that we can "fill the cache" even from Get-methods
      * declared as "const".  
      */
-    mutable uint256 hashBlock;
-    mutable uint256 hashFinalTx;
+    mutable boost::optional<uint256> hashBlock;
+    mutable boost::optional<uint256> hashFinalTx;
     mutable CCoinsMap cacheCoins;
 
     /* Cached dynamic memory usage for the inner CCoins objects. */

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2557,7 +2557,7 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
             // activation. Normal tip validation in init.cpp will halt on this
             // error and notify that the user that their block database is
             // corrupted, which is fixed by starting with -reindex=1.
-            return state.DoS(100, error("%s: prior block-final tx hash not found; corruption likely!", __func__),
+            return state.DoS(100, error("%s: prior block-final tx hash %s not found; corruption likely!", __func__, view.GetFinalTx().GetHex()),
                              REJECT_INVALID, "corrupt-db-no-blockfinal-hash", true);
         }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2554,11 +2554,11 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
             // This state of affairs can potentially happen when performing an
             // upgrade from a prior node version to one which supports
             // validation of block-final transaction rules, but *after* rule
-            // activation. Normal tip validation in init.cpp will halt on this
-            // error and notify that the user that their block database is
-            // corrupted, which is fixed by starting with -reindex=1.
-            return state.DoS(100, error("%s: prior block-final tx hash %s not found; corruption likely!", __func__, view.GetFinalTx().GetHex()),
-                             REJECT_INVALID, "corrupt-db-no-blockfinal-hash", true);
+            // activation.  Normal tip validation in init.cpp will halt on
+            // this error and notify that the user that their block database
+            // is corrupted, which is fixed by starting with -reindex=1.
+            state.SetCorruptionPossible();
+            return AbortNode(state, strprintf("%s: prior block-final tx hash %s not found; corruption likely!", __func__, view.GetFinalTx().GetHex()), _("Database corruption likely.  Try restarting with `-reindex=1`."));
         }
 
         // The output spent by the very first block-final transaction is

--- a/src/main.h
+++ b/src/main.h
@@ -642,6 +642,9 @@ bool DisconnectBlock(const CBlock& block, CValidationState& state, const CBlockI
 /** Check a block is completely valid from start to finish (only works on top of our current best block, with cs_main held) */
 bool TestBlockValidity(CValidationState& state, const CChainParams& chainparams, const CBlock& block, CBlockIndex* pindexPrev, bool fCheckPOW = true, bool fCheckMerkleRoot = true);
 
+/** Check whether block-final transaction rules are enforced for block. */
+bool IsBlockFinalEnforced(const CBlockIndex* pindexPrev, const Consensus::Params& params);
+
 /** Check whether witness commitments are required for block. */
 bool IsWitnessEnabled(const CBlockIndex* pindexPrev, const Consensus::Params& params);
 

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -86,8 +86,7 @@ bool CCoinsViewDB::BatchWrite(CCoinsMap &mapCoins, const uint256 &hashBlock, con
         CCoinsMap::iterator itOld = it++;
         mapCoins.erase(itOld);
     }
-    if (!hashBlock.IsNull())
-        batch.Write(DB_BEST_BLOCK, hashBlock);
+    batch.Write(DB_BEST_BLOCK, hashBlock);
     batch.Write(DB_LAST_TX, hashFinalTx);
 
     LogPrint("coindb", "Committing %u changed transactions (out of %u) to coin database...\n", (unsigned int)changed, (unsigned int)count);


### PR DESCRIPTION
It was been observed in PR #70 that v13 sometimes hangs on start and requires restarting with `-reindex=1`, and clearing the ban list in order to make progress again.  It turns out the root cause of this error is that some invalid cache data is being flushed to disk at one or more points during startup.  This PR includes a number of changes related to fixing this problem:

1. The debug output is improved with changes that were helpful in isolating the error.

2. A clean node shutdown is triggered if corruption is detected during operation, rather than entering a peer-banning infinite loop as is the observed behavior on v13.2-11780.

3. During initialization the block-final tx hash in the database is checked, and if not valid (whether missing or corrupted), a reindex from the point of activation of the block-final fork is triggered.  This is modeled on the behavior of an upgraded segwit node, which also resynchronizes from the point of activation on first startup after upgrading.

4. Explicitly track which fields in the cache are valid, so as to not write invalid data to the database when flushed.

(4) actually fixes the root cause; (1) - (3) are to make sure that if a similar issue arises again, the code will be smart enough to restore its internal state and recover operation, and to recover state for any corrupted nodes in the wild that upgrade in the next release.

Also, in testing it was observed that this fixes #48. It turns out the lurking reorg-invalidation problem has this flushing of invalid cache data as its root cause too! We therefore re-enable the pruning RPC test which was previously clobbered by the block-final tx changes.