### PR TITLE
[Stratum] Prevent sending double work notification to miner that finds block

### DIFF
--- a/src/stratum.cpp
+++ b/src/stratum.cpp
@@ -793,6 +793,15 @@ void BlockWatcher()
             if (!client.m_authorized) {
                 continue;
             }
+            // Ignore clients that are already working on the new block.
+            // Typically this is just the miner that found the block, who was
+            // immediately sent a work update.  This check avoids sending that
+            // work notification again, moments later.  Due to race conditions
+            // there could be more than one miner that have already received an
+            // update, however.
+            if (client.m_last_tip == chainActive.Tip()) {
+                continue;
+            }
             // Get new work
             std::string data;
             try {


### PR DESCRIPTION
When responding to a new block notification and sending updated work to miners, ignore clients that are already working on the new block.  Typically this is just the miner that found the block, who was immediately sent a work update when they submitted their winning share.  The code is updated to avoid sending work to that miner again when the new-block notification is handled, moments later.  Due to race conditions there could be more than one miner that have already received an update, however, so we check each miner rather than jus flagging the one that found a block.