### PR TITLE
[Merkle] Add stable Merkle branch proof APIs.

### DIFF
--- a/src/consensus/merkle.h
+++ b/src/consensus/merkle.h
@@ -34,6 +34,27 @@ std::vector<uint256> ComputeMerkleBranch(const std::vector<uint256>& leaves, uin
 uint256 ComputeMerkleRootFromBranch(const uint256& leaf, const std::vector<uint256>& branch, uint32_t position);
 
 /*
+ * Produces or validates a branch proof of a Merkle tree which does NOT
+ * include redundant hashes in the branch proof vector.  The Satoshi Merkle
+ * tree design will duplicate hash values along the right-most branch of the
+ * tree if it is not a power of 2 in size.  In the above APIs, these hashes
+ * are included in the branch proof.  This not only wastes space, but is
+ * problematic because these duplicated hashes are dependent on the leaf value
+ * being proven, so the proof can't be used to recalculate a new root if the
+ * leaf value changes.
+ *
+ * The following API for generating Merkle tree branch proofs does not include
+ * duplicated hashes, so the result is both shorter (if it is along the right-
+ * hand side of an unbalanced tree) and can be safely used to recalculate root
+ * hash values.
+ *
+ * Note that the size of the original tree must be known at validation time.
+ */
+
+std::vector<uint256> ComputeStableMerkleBranch(const std::vector<uint256>& leaves, uint32_t position);
+uint256 ComputeStableMerkleRootFromBranch(const uint256& leaf, const std::vector<uint256>& branch, uint32_t position, uint32_t size);
+
+/*
  * Has similar API semantics, but produces Merkle roots and validates
  * branches 2.32x as fast as the Satoshi Merkle tree, and without the
  * mutation vulnerability.  ComputeFastMerkleBranch returns a pair

--- a/src/test/merkle_tests.cpp
+++ b/src/test/merkle_tests.cpp
@@ -148,6 +148,76 @@ BOOST_AUTO_TEST_CASE(merkle_test)
     }
 }
 
+BOOST_AUTO_TEST_CASE(merkle_stable_branch)
+{
+    using std::swap;
+
+    std::string alphabet("abcdefghijklmnopqrstuv");
+    BOOST_CHECK_EQUAL(alphabet.length(), 22); // last index == 0b10101
+
+    uint256 hashZ;
+    CHash256().Write((const unsigned char*)"z", 1).Finalize(hashZ.begin());
+    BOOST_CHECK(hashZ == uint256S("ca23f71f669346e53eb7679749b368c9ec09109b798ba542487224b79cd47cc2"));
+
+    std::vector<uint256> leaves;
+    for (auto c : alphabet) {
+        uint256 hash;
+        CHash256().Write((unsigned char*)&c, 1).Finalize(hash.begin());
+        leaves.push_back(hash);
+    }
+    BOOST_CHECK_EQUAL(leaves.size(), 22);
+    BOOST_CHECK(leaves[0] == uint256S("d8f244c159278ea8cfffcbe1c463edef33d92d11d36ac3c62efd3eb7ff3a5dbf")); // just check the first hash, of 'a'
+
+    for (uint32_t i = 0; i < leaves.size(); ++i) {
+        std::vector<uint256> old_branch = ComputeMerkleBranch(leaves, i);
+        std::vector<uint256> new_branch = ComputeStableMerkleBranch(leaves, i);
+
+        // Both branches should generate the same Merkle root.
+        auto root = ComputeMerkleRoot(leaves, nullptr);
+        BOOST_CHECK(root == ComputeMerkleRootFromBranch(leaves[i], old_branch, i));
+        BOOST_CHECK(root == ComputeStableMerkleRootFromBranch(leaves[i], new_branch, i, leaves.size()));
+
+        if (i < 16) {
+            // The first 16 branches are <0b100000, and therefore go down the
+            // left-hand side of the tree and have no duplicated hashes.  The
+            // results should therefore be identical with the old API.
+            BOOST_CHECK(old_branch == new_branch);
+
+            // Try replacing the leaf with hashZ
+            swap(leaves[i], hashZ);
+            root = ComputeMerkleRoot(leaves, nullptr);
+            BOOST_CHECK(root == ComputeMerkleRootFromBranch(leaves[i], old_branch, i));
+            BOOST_CHECK(root == ComputeStableMerkleRootFromBranch(leaves[i], new_branch, i, leaves.size()));
+            swap(hashZ, leaves[i]); // revert
+        } else {
+            // All of the remaining branches have at least one duplicated
+            // hash.  The new-style branch is shorter than the old-style
+            // branch because it does not include that hash.
+            BOOST_CHECK_EQUAL(old_branch.size(), 5);
+            switch (i) {
+                case 16: // 0b10000
+                case 17: // 0b10001
+                case 18: // 0b10010
+                case 19: // 0b10011
+                    BOOST_CHECK_EQUAL(new_branch.size(), 4);
+                    break;
+                case 20: // 0b10100
+                case 21: // 0b10101
+                    BOOST_CHECK_EQUAL(new_branch.size(), 3);
+                    break;
+            }
+
+            // And if we swap leaf values, only the new-style branch generates
+            // correct root hashes.
+            swap(leaves[i], hashZ);
+            root = ComputeMerkleRoot(leaves, nullptr);
+            BOOST_CHECK(root != ComputeMerkleRootFromBranch(leaves[i], old_branch, i));
+            BOOST_CHECK(root == ComputeStableMerkleRootFromBranch(leaves[i], new_branch, i, leaves.size()));
+            swap(hashZ, leaves[i]); // revert
+        }
+    }
+}
+
 BOOST_AUTO_TEST_CASE(merkle_link)
 {
     BOOST_CHECK(sizeof(MerkleLink) == 1);


### PR DESCRIPTION
The Satoshi Merkle tree design will duplicate hash values along the right-most branch of the tree if it is not a power of 2 in size.  In the regular Merkle branch APIs, these hashes are included in the branch proof.  This not only wastes space, but is problematic because these duplicated hashes are dependent on the leaf value being proven, so the proof can't be used to recalculate a new root if the leaf value changes.

This new API for generating Merkle tree branch proofs does not include duplicated hashes, so the result is both shorter (if it is along the right-hand side of an unbalanced tree) and can be safely used to recalculate root hash values.