### PR TITLE
[Stratum] Use Merkle branches for fast recalculation of work units.

### DIFF
--- a/src/stratum.cpp
+++ b/src/stratum.cpp
@@ -95,13 +95,20 @@ void StratumClient::GenSecret()
 }
 
 struct StratumWork {
-    const CBlockIndex *m_prev_block_index;
     CBlockTemplate m_block_template;
-    std::vector<uint256> m_cb_branch;
     bool m_is_witness_enabled;
+    // First we generate the segwit commitment for the miner's coinbase with
+    // ComputeFastMerkleBranch.
+    std::vector<uint256> m_cb_wit_branch;
+    // Then we compute the initial right-branch for the block-tx Merkle tree
+    // using ComputeStableMerkleBranch...
+    std::vector<uint256> m_bf_branch;
+    // ...which is appended to the end of m_cb_branch so we can compute the
+    // block's hashMerkleRoot with ComputeMerkleBranch.
+    std::vector<uint256> m_cb_branch;
 
-    StratumWork() : m_prev_block_index(0), m_is_witness_enabled(false) { };
-    StratumWork(const CBlockIndex* prev_blocK_index, const CBlockTemplate& block_template);
+    StratumWork() : m_is_witness_enabled(false) { };
+    StratumWork(const CBlockTemplate& block_template, bool is_witness_enabled);
 
     CBlock& GetBlock()
       { return m_block_template.block; }
@@ -109,24 +116,65 @@ struct StratumWork {
       { return m_block_template.block; }
 };
 
-StratumWork::StratumWork(const CBlockIndex* prev_block_index, const CBlockTemplate& block_template)
-    : m_prev_block_index(prev_block_index)
-    , m_block_template(block_template)
+StratumWork::StratumWork(const CBlockTemplate& block_template, bool is_witness_enabled)
+    : m_block_template(block_template)
+    , m_is_witness_enabled(is_witness_enabled)
 {
-    m_is_witness_enabled = IsWitnessEnabled(prev_block_index, Params().GetConsensus());
-    if (!m_is_witness_enabled) {
-        m_cb_branch = BlockMerkleBranch(m_block_template.block, 0);
+    // How we use the various branch fields depends on whether segregated
+    // witness is active.  If segwit is not active, m_cb_branch contains the
+    // Merkle proof for the coinbase.  If segwit is active, we also use this
+    // field in a different way, so we compute it in both branches.
+    std::vector<uint256> leaves;
+    for (auto tx : m_block_template.block.vtx) {
+        leaves.push_back(tx.GetHash());
+    }
+    m_cb_branch = ComputeMerkleBranch(leaves, 0);
+    // If segwit is not active, we're done.  Otherwise...
+    if (m_is_witness_enabled) {
+        // The final hash in m_cb_branch is the right-hand branch from
+        // the root, which contains the block-final transaction (and
+        // therefore the segwit commitment).
+        m_cb_branch.pop_back();
+        // To calculate the initial right-side hash, we need the path
+        // to the root from the coinbase's position.  Again, the final
+        // hash won't be known ahead of time because it depends on the
+        // contents of the coinbase (which depends on both the miner's
+        // payout address and the specific extranonce2 used).
+        m_bf_branch = ComputeStableMerkleBranch(leaves, leaves.size()-1);
+        m_bf_branch.pop_back();
+        // To calculate the segwit commitment for the block-final tx,
+        // we use a proof from the coinbase's position of the witness
+        // Merkle tree.
+        for (int i = 1; i < m_block_template.block.vtx.size()-1; ++i) {
+            leaves[i] = m_block_template.block.vtx[i].GetWitnessHash();
+        }
+        CMutableTransaction bf(m_block_template.block.vtx.back());
+        CScript& scriptPubKey = bf.vout.back().scriptPubKey;
+        assert(scriptPubKey.size() >= 37);
+        std::fill_n(&scriptPubKey[scriptPubKey.size()-37], 33, 0x00);
+        leaves.back() = bf.GetHash();
+        m_cb_wit_branch = ComputeFastMerkleBranch(leaves, 0).first;
     }
 };
 
 void UpdateSegwitCommitment(const StratumWork& current_work, CMutableTransaction& cb, CMutableTransaction& bf, std::vector<uint256>& cb_branch)
 {
-    CBlock block2(current_work.GetBlock());
-    block2.vtx.front() = CTransaction(cb);
-    GenerateCoinbaseCommitment(block2, current_work.m_prev_block_index, Params().GetConsensus());
-    cb = block2.vtx.front();
-    bf = block2.vtx.back();
-    cb_branch = BlockMerkleBranch(block2, 0);
+    // Calculate witnessroot
+    CMutableTransaction cb2(cb);
+    cb2.vin.front().scriptSig = CScript();
+    cb2.vin.front().nSequence = 0;
+    auto witnessroot = ComputeFastMerkleRootFromBranch(cb2.GetHash(), current_work.m_cb_wit_branch, 0, nullptr);
+
+    // Build block-final tx
+    CScript& scriptPubKey = bf.vout.back().scriptPubKey;
+    scriptPubKey[scriptPubKey.size()-37] = 0x01;
+    std::copy(witnessroot.begin(),
+              witnessroot.end(),
+              &scriptPubKey[scriptPubKey.size()-36]);
+
+    // Calculate right-branch
+    uint32_t size = current_work.GetBlock().vtx.size();
+    cb_branch.push_back(ComputeStableMerkleRootFromBranch(bf.GetHash(), current_work.m_bf_branch, size - 1, size));
 }
 
 //! Critical seciton guarding access to any of the stratum global state
@@ -209,7 +257,7 @@ std::string GetWorkUnit(StratumClient& client)
         new_work->block.hashMerkleRoot = BlockMerkleRoot(new_work->block);
 
         job_id = new_work->block.GetHash();
-        work_templates[job_id] = StratumWork(tip_new, *new_work);
+        work_templates[job_id] = StratumWork(*new_work, !new_work->block.vtx[0].wit.IsEmpty());
         tip = tip_new;
 
         transactions_updated_last = mempool.GetTransactionsUpdated();


### PR DESCRIPTION
Customizing a block template for a particular miner involves changing the coinbase outputs which causes the segwit commitment to be updated.  Presently the stratum code makes a copy of the entire block before manipulating it, which would be expensive for large blocks.  This commit changes that behavior to use pre-calculated Merkle branches for the coinbase and the block-final transaction, which massively reduces the cost of updating the block template for large blocks.

Depends on #78 