### PR TITLE
[Stratum] Nest initial response from stratum server.

### DIFF
--- a/src/stratum.cpp
+++ b/src/stratum.cpp
@@ -479,13 +479,15 @@ UniValue stratum_mining_subscribe(StratumClient& client, const UniValue& params)
     // params[1] is the subscription ID for reconnect, which we
     // currently do not support.
 
-    UniValue ret(UniValue::VARR);
+    UniValue msg(UniValue::VARR);
 
     UniValue notify(UniValue::VARR);
     notify.push_back("mining.notify");
     notify.push_back("ae6812eb4cd7735a302a8a9dd95cf71f");
-    ret.push_back(notify);
+    msg.push_back(notify);
 
+    UniValue ret(UniValue::VARR);
+    ret.push_back(msg);
     ret.push_back(""); //        extranonce1
     ret.push_back(4);  // sizeof(extranonce2)
 


### PR DESCRIPTION
According to the stratum protocol specification, the first parameter is supposed to be an array of messages, with each message being an array.  So it is a list-of-lists, which is not what the prior behavior was.  This patch fixes a bug in the initial stratum server implementation.