### PR TITLE
[Merkle] Perform excess repeated hashing on shortened "stable" Merkle roots.

### DIFF
--- a/src/consensus/merkle.cpp
+++ b/src/consensus/merkle.cpp
@@ -227,6 +227,18 @@ uint256 ComputeStableMerkleRootFromBranch(const uint256& leaf, const std::vector
         pos >>= 1;
         size >>= 1;
     }
+    /* Perform any repeated hashes between the last given branch hash and the
+     * next (missing) hash.  The particular use case for this is computing the
+     * root of a subtree, such as the recomputing the block-final transaction
+     * branch of the Merkle tree when the segwit commitment is updated.  In all
+     * practical situations you want these final repeated hashes to be done,
+     * since the result is the hash value which actually shows up in other
+     * branches. */
+    while (size && (pos == size) && !(pos & 1)) {
+        hash = Hash(BEGIN(hash), END(hash), BEGIN(hash), END(hash));
+        pos >>= 1;
+        size >>= 1;
+    }
     return hash;
 }
 


### PR DESCRIPTION
This is an update to the so-called "stable" Merkle branch code, but it fixes a bug in the stratum server API which shows up on witness blocks with a transaction count that is not 2^n or 2^n + 2^(n-1).

Since v13.2.2, the stratum mining code does a trick to avoid copying blocks when verifying shares: it uses the stable Merkle branch code to recompute the right-half of the transaction Merkle tree when the segwit commitment is updated.  The trick is that it pops off the top hash (representing the left-hand side of the tree), so that the recomputed "root" is actually the root of the right-side subtree, which is the last hash of the coinbase branch proof.  However prior to this fix, any duplicated hashes between the last "real" hash value of the right subtree and its root were not performed.  This resulted in an incorrect value being used, and therefore the incorrect coinbase Merkle branch being reported to miners.