### PR TITLE
[Hard-Fork] Split scheduled hard-forks into "protocol cleanup" and "size expansion"

### DIFF
--- a/src/blockencodings.cpp
+++ b/src/blockencodings.cpp
@@ -64,11 +64,11 @@ uint64_t CBlockHeaderAndShortTxIDs::GetShortID(const uint256& txhash) const {
 
 ReadStatus PartiallyDownloadedBlock::InitData(const CBlockHeaderAndShortTxIDs& cmpctblock) {
     // Check for protocol cleanup rule activation
-    const bool protocol_cleanup = IsProtocolCleanupActive(Params().GetConsensus(), GetAdjustedTime());
+    const bool size_expansion = IsSizeExpansionActive(Params().GetConsensus(), GetAdjustedTime());
 
     if (cmpctblock.header.IsNull() || (cmpctblock.shorttxids.empty() && cmpctblock.prefilledtxn.empty()))
         return READ_STATUS_INVALID;
-    if (cmpctblock.shorttxids.size() + cmpctblock.prefilledtxn.size() > (protocol_cleanup ? PROTOCOL_CLEANUP_MAX_BLOCK_BASE_SIZE : MAX_BLOCK_BASE_SIZE) / MIN_TRANSACTION_BASE_SIZE)
+    if (cmpctblock.shorttxids.size() + cmpctblock.prefilledtxn.size() > (size_expansion ? SIZE_EXPANSION_MAX_BLOCK_BASE_SIZE : MAX_BLOCK_BASE_SIZE) / MIN_TRANSACTION_BASE_SIZE)
         return READ_STATUS_INVALID;
 
     assert(header.IsNull() && txn_available.empty());

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -125,26 +125,33 @@ public:
         // This is 4PM PDT, 7PM EDT, and 9AM JST.
         consensus.verify_coinbase_lock_time_timeout = 1569974400;
 
-         /**
-         * The protocol cleanup rule change is scheduled for
-         * activation on 2 June 2022 at midnight UTC. This is 4PM
-         * PDT, 7PM EDT, and 9AM JST.  Since the activation time is
-         * median-time-past, it'll actually trigger about an hour
-         * after this wall-clock time.
-         *
-         * This date is chosen to be roughly 2 years after the expected
-         * release date of official binaries. While the Freicoin developer
-         * team doesn't have the resources to provide strong ongoing support
-         * beyond emergency fixes, we nevertheless have an ideal goal of
-         * supporting release binaries for up to 2 years following the first
-         * release from that series. Any release of a new series prior to the
-         * deployment of forward blocks should set this to be at least two
-         * years from the time of release. When forward blocks is deployed,
-         * this parameter should be set to the highest value used in prior
-         * releases, and becomes the earliest time at which the hard-fork
-         * rules can activate.
+        /**
+         * The protocol cleanup rule change is scheduled for activation on 16
+         * Jan 2021 at midnight UTC.  This is 4PM PDT, 7PM EDT, and 9AM JST.
+         * Since the activation time is median-time-past, it'll actually trigger
+         * about 90 minutes after this wall-clock time.  Note that the auxpow
+         * soft-fork must activate before the protocol cleanup rule change.
          */
-        consensus.protocol_cleanup_activation_time = 1654128000;
+        consensus.protocol_cleanup_activation_time = 1610755200;
+
+        /**
+         * The size expansion rule change is scheduled for activation on 2 Sept
+         * 2022 at midnight UTC.  This is 4PM PDT, 7PM EDT, and 9AM JST.  Since
+         * the activation time is median-time-past, it'll actually trigger about
+         * 90 minutes after this wall-clock time.
+         *
+         * This date is chosen to be roughly 2 years after the expected release
+         * date of official binaries. While the Freicoin developer team doesn't
+         * have the resources to provide strong ongoing support beyond emergency
+         * fixes, we nevertheless have an ideal goal of supporting release
+         * binaries for up to 2 years following the first release from that
+         * series. Any release of a new series prior to the deployment of
+         * forward blocks should set this to be at least two years from the time
+         * of release.  When forward blocks is deployed, this parameter should
+         * be set to the highest value used in prior releases, and becomes the
+         * earliest time at which the hard-fork rules can activate.
+         */
+        consensus.size_expansion_activation_time = 1662076800;
 
         consensus.original_adjust_interval = 2016; // two weeks
         consensus.filtered_adjust_interval = 9; // 1.5 hrs
@@ -302,9 +309,13 @@ public:
         consensus.verify_coinbase_lock_time_activation_height = 1;
         consensus.verify_coinbase_lock_time_timeout = 0;
 
+        // Two months prior to main net
+        // 16 November 2020 00:00:00 UTC
+        consensus.protocol_cleanup_activation_time = 1605484800;
+
         // Nine months prior to main net
-        // 2 September 2021 00:00:00 UTC
-        consensus.protocol_cleanup_activation_time = 1630540800;
+        // 16 January 2022 00:00:00 UTC
+        consensus.size_expansion_activation_time = 1642291200;
 
         consensus.original_adjust_interval = 2016; // two weeks
         consensus.filtered_adjust_interval = 9; // 1.5 hrs
@@ -443,6 +454,7 @@ public:
          * which is unacceptable time-dependency in the build process.
          */
         consensus.protocol_cleanup_activation_time = std::numeric_limits<int64_t>::max();
+        consensus.size_expansion_activation_time = std::numeric_limits<int64_t>::max();
 
         consensus.original_adjust_interval = 2016; // two weeks
         consensus.filtered_adjust_interval = 9; // 1.5 hrs

--- a/src/consensus/consensus.h
+++ b/src/consensus/consensus.h
@@ -22,6 +22,10 @@
 
 #include <stdint.h>
 
+typedef unsigned int RuleSet;
+static const RuleSet PROTOCOL_CLEANUP = 1;
+static const RuleSet SIZE_EXPANSION   = 2;
+
 /** The maximum number of hashes allowed in the path from the auxiliary block
  ** header to auxiliary block-final transaction.  Sufficient to support 2GB
  ** blocks on the auxiliary block chain. */
@@ -38,23 +42,23 @@ static const unsigned int MAX_BLOCK_WEIGHT = 4000000;
  ** proof-of-work data, in bytes (network rule) */
 static const unsigned int MAX_BLOCK_BASE_SIZE = 1000000;
 /** The maximum size of a blk?????.dat file (since v10)
- ** (post-cleanup network rule) */
-static const unsigned int PROTOCOL_CLEANUP_MAX_BLOCKFILE_SIZE = 0x7f000000; // (2048 - 16) MiB
+ ** (post-expansion network rule) */
+static const unsigned int SIZE_EXPANSION_MAX_BLOCKFILE_SIZE = 0x7f000000; // (2048 - 16) MiB
 /** The maximum serialized block size is constrained by the need to
  ** fit inside a block file, which has an additional 8 bytes of file
- ** data per block. (post-cleanup consensus rule) */
-static const unsigned int PROTOCOL_CLEANUP_MAX_BLOCK_SERIALIZED_SIZE = 0x7efffff8; // PROTOCOL_CLEANUP_MAX_BLOCKFILE_SIZE - 8
-/** The actual hard block size limit post-activation of the protocol
- ** cleanup rules is PROTOCOL_CLEANUP_MAX_BLOCKFILE_SIZE - 8, but this
+ ** data per block. (post-expansion consensus rule) */
+static const unsigned int SIZE_EXPANSION_MAX_BLOCK_SERIALIZED_SIZE = 0x7efffff8; // SIZE_EXPANSION_MAX_BLOCKFILE_SIZE - 8
+/** The actual hard block size limit post-activation of the size
+ ** expansion rules is SIZE_EXPANSION_MAX_BLOCKFILE_SIZE - 8, but this
  ** limit can't be reached for any real block because classic blocks
  ** have a minimum size and non-witness data has quadruple weight.  So
  ** we can still keep the post-fork weight limit as a relatively round
- ** number in binary, for faster calculations.  (post-cleanup
+ ** number in binary, for faster calculations.  (post-expansion
  ** consensus rule) */
-static const unsigned int PROTOCOL_CLEANUP_MAX_BLOCK_WEIGHT = 0x7f000000; // (2048 - 16) MiB
+static const unsigned int SIZE_EXPANSION_MAX_BLOCK_WEIGHT = 0x7f000000; // (2048 - 16) MiB
 /** The maximum block base block size is 1/4 the maximum block weight.
- ** (post-cleanup consensus rule) */
-static const unsigned int PROTOCOL_CLEANUP_MAX_BLOCK_BASE_SIZE = 0x1fc00000; // 508 MiB
+ ** (post-expansion consensus rule) */
+static const unsigned int SIZE_EXPANSION_MAX_BLOCK_BASE_SIZE = 0x1fc00000; // 508 MiB
 /** The maximum allowed number of signature check operations in a block (network rule) */
 static const int64_t MAX_BLOCK_SIGOPS_COST = 80000;
 /** Coinbase transaction outputs can only be spent after this number of new blocks (network rule) */

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -88,6 +88,8 @@ struct Params {
     BIP9Deployment vDeployments[MAX_VERSION_BITS_DEPLOYMENTS];
     /** Scheduled protocol cleanup rule change */
     int64_t protocol_cleanup_activation_time;
+    /** Scheduled size expansion rule change */
+    int64_t size_expansion_activation_time;
     /** Proof of work parameters */
     uint256 powLimit;
     uint256 aux_pow_limit;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -884,8 +884,7 @@ static std::pair<int, int64_t> CalculateSequenceLocks(const CTransaction &tx, in
 
     // Bitcoin also has the requirement that tx.nVersion be not 0 or
     // 1, as a soft-fork upgrade protection. We don't have the same
-    // requirement since we lack the ability to change tx.nVersion
-    // until the protocol cleanup rule-change activates.
+    // requirement.
     bool fEnforceBIP68 = (flags & LOCKTIME_VERIFY_SEQUENCE) != 0;
 
     // Do not enforce sequence numbers as a relative lock time
@@ -1082,15 +1081,15 @@ int64_t GetTransactionSigOpCost(const CTransaction& tx, const CCoinsViewCache& i
 
 
 
-bool CheckTransaction(const CTransaction& tx, CValidationState &state, bool protocol_cleanup)
+bool CheckTransaction(const CTransaction& tx, CValidationState &state, RuleSet rules)
 {
     // Basic checks that don't depend on any context
     if (tx.vin.empty())
         return state.DoS(10, false, REJECT_INVALID, "bad-txns-vin-empty");
-    if (!protocol_cleanup && tx.vout.empty())
+    if (!(rules & PROTOCOL_CLEANUP) && tx.vout.empty())
         return state.DoS(10, false, REJECT_INVALID, "bad-txns-vout-empty");
     // Size limits (this doesn't take the witness into account, as that hasn't been checked for malleability)
-    if (::GetSerializeSize(tx, SER_NETWORK, PROTOCOL_VERSION | SERIALIZE_TRANSACTION_NO_WITNESS) > (protocol_cleanup ? PROTOCOL_CLEANUP_MAX_BLOCK_BASE_SIZE : MAX_BLOCK_BASE_SIZE))
+    if (::GetSerializeSize(tx, SER_NETWORK, PROTOCOL_VERSION | SERIALIZE_TRANSACTION_NO_WITNESS) > ((rules & SIZE_EXPANSION) ? SIZE_EXPANSION_MAX_BLOCK_BASE_SIZE : MAX_BLOCK_BASE_SIZE))
         return state.DoS(100, false, REJECT_INVALID, "bad-txns-oversize");
 
     // Check for negative or overflow output values
@@ -1117,7 +1116,7 @@ bool CheckTransaction(const CTransaction& tx, CValidationState &state, bool prot
 
     if (tx.IsCoinBase())
     {
-        if (!protocol_cleanup && (tx.vin[0].scriptSig.size() < 2 || tx.vin[0].scriptSig.size() > 100))
+        if (!(rules & PROTOCOL_CLEANUP) && (tx.vin[0].scriptSig.size() < 2 || tx.vin[0].scriptSig.size() > 100))
             return state.DoS(100, false, REJECT_INVALID, "bad-cb-length");
     }
     else
@@ -1958,7 +1957,7 @@ int GetSpendHeight(const CCoinsViewCache& inputs)
 }
 
 namespace Consensus {
-bool CheckTxInputs(const CTransaction& tx, CValidationState& state, const CCoinsViewCache& inputs, int per_input_adjustment, int nSpendHeight, bool protocol_cleanup)
+bool CheckTxInputs(const CTransaction& tx, CValidationState& state, const CCoinsViewCache& inputs, int per_input_adjustment, int nSpendHeight, RuleSet rules)
 {
         // This doesn't trigger the DoS code on purpose; if it did, it would make it easier
         // for an attacker to attempt to split the network.
@@ -1975,7 +1974,7 @@ bool CheckTxInputs(const CTransaction& tx, CValidationState& state, const CCoins
 
             // If prev is coinbase, check that it's matured
             if (coins->IsCoinBase()) {
-                if (nSpendHeight - coins->nHeight < (protocol_cleanup ? 1 : COINBASE_MATURITY))
+                if (nSpendHeight - coins->nHeight < ((rules & SIZE_EXPANSION) ? 1 : COINBASE_MATURITY))
                     return state.Invalid(false,
                         REJECT_INVALID, "bad-txns-premature-spend-of-coinbase",
                         strprintf("tried to spend coinbase at depth %d", nSpendHeight - coins->nHeight));
@@ -1984,7 +1983,7 @@ bool CheckTxInputs(const CTransaction& tx, CValidationState& state, const CCoins
             // Check that lock_height is monotonically increasing.
             // This restriction is removed for zero-valued inputs in
             // the protocol cleanup.
-            if ((coins->vout[prevout.n].GetReferenceValue() || !protocol_cleanup) && !(::Params().GetConsensus().bitcoin_mode) && (tx.lock_height < coins->refheight)) {
+            if ((coins->vout[prevout.n].GetReferenceValue() || !(rules & PROTOCOL_CLEANUP)) && !(::Params().GetConsensus().bitcoin_mode) && (tx.lock_height < coins->refheight)) {
                 return state.DoS(100, error("CheckInputs(): input refheight less than tx lock_height"),
                                  REJECT_INVALID, "bad-txns-non-monotonic-lock-height");
             }
@@ -2015,11 +2014,17 @@ bool CheckTxInputs(const CTransaction& tx, CValidationState& state, const CCoins
 bool CheckInputs(const CTransaction& tx, CValidationState &state, const CCoinsViewCache &inputs, int per_input_adjustment, bool fScriptChecks, unsigned int flags, bool cacheStore, PrecomputedTransactionData& txdata, std::vector<CScriptCheck> *pvChecks)
 {
     // Check for activation of rule changes
-    const bool protocol_cleanup = (flags & SCRIPT_VERIFY_PROTOCOL_CLEANUP) != 0;
+    RuleSet rules = 0;
+    if (flags & SCRIPT_VERIFY_PROTOCOL_CLEANUP) {
+        rules |= PROTOCOL_CLEANUP;
+    }
+    if (flags & SCRIPT_VERIFY_SIZE_EXPANSION) {
+        rules |= SIZE_EXPANSION;
+    }
 
     if (!tx.IsCoinBase())
     {
-        if (!Consensus::CheckTxInputs(tx, state, inputs, per_input_adjustment, GetSpendHeight(inputs), protocol_cleanup))
+        if (!Consensus::CheckTxInputs(tx, state, inputs, per_input_adjustment, GetSpendHeight(inputs), rules))
             return false;
 
         if (pvChecks)
@@ -2406,7 +2411,7 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
     }
 
     // Check for activation of rule changes
-    const bool protocol_cleanup = IsProtocolCleanupActive(chainparams.GetConsensus(), pindex->pprev);
+    const RuleSet rules = GetActiveRules(chainparams.GetConsensus(), pindex->pprev);
 
     bool fScriptChecks = true;
     if (fCheckpointsEnabled) {
@@ -2460,8 +2465,11 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
     bool fStrictPayToScriptHash = (pindex->GetBlockTime() >= nBIP16SwitchTime);
 
     unsigned int flags = fStrictPayToScriptHash ? SCRIPT_VERIFY_P2SH : SCRIPT_VERIFY_NONE;
-    if (protocol_cleanup) {
+    if (rules & PROTOCOL_CLEANUP) {
         flags |= SCRIPT_VERIFY_PROTOCOL_CLEANUP;
+    }
+    if (rules & SIZE_EXPANSION) {
+        flags |= SCRIPT_VERIFY_SIZE_EXPANSION;
     }
 
     // Enforce the DERSIG (BIP66) rules, at the point in which
@@ -2688,7 +2696,7 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
         // * legacy (always)
         // * p2sh (when P2SH enabled in flags and excludes coinbase)
         nSigOpsCost += GetTransactionSigOpCost(tx, view, flags);
-        if (!protocol_cleanup && nSigOpsCost > MAX_BLOCK_SIGOPS_COST)
+        if (!(rules & PROTOCOL_CLEANUP) && nSigOpsCost > MAX_BLOCK_SIGOPS_COST)
             return state.DoS(100, error("ConnectBlock(): too many sigops"),
                              REJECT_INVALID, "bad-blk-sigops");
 
@@ -3516,10 +3524,10 @@ bool FindBlockPos(CValidationState &state, CDiskBlockPos &pos, unsigned int nAdd
         vinfoBlockFile.resize(nFile + 1);
     }
 
-    const bool protocol_cleanup = IsProtocolCleanupActive(Params().GetConsensus(), GetAdjustedTime());
+    const bool size_expansion = IsSizeExpansionActive(Params().GetConsensus(), GetAdjustedTime());
 
     if (!fKnown) {
-        while (vinfoBlockFile[nFile].nSize + nAddSize >= (protocol_cleanup ? PROTOCOL_CLEANUP_MAX_BLOCKFILE_SIZE : MAX_BLOCKFILE_SIZE)) {
+        while (vinfoBlockFile[nFile].nSize + nAddSize >= (size_expansion ? SIZE_EXPANSION_MAX_BLOCKFILE_SIZE : MAX_BLOCKFILE_SIZE)) {
             nFile++;
             if (vinfoBlockFile.size() <= nFile) {
                 vinfoBlockFile.resize(nFile + 1);
@@ -3690,8 +3698,8 @@ bool CheckBlock(const CBlock& block, CValidationState& state, const Consensus::P
         }
     }
 
-    // Check if the protocol-cleanup fork has activated
-    const bool protocol_cleanup = IsProtocolCleanupActive(Params().GetConsensus(), block);
+    // Check if the size-expansion fork has activated
+    const RuleSet rules = GetActiveRules(Params().GetConsensus(), block);
 
     // All potential-corruption validation must be done before we do any
     // transaction validation, as otherwise we may mark the header as invalid
@@ -3700,7 +3708,7 @@ bool CheckBlock(const CBlock& block, CValidationState& state, const Consensus::P
     // checks that use witness data may be performed here.
 
     // Size limits
-    const std::size_t max_block_base_size = protocol_cleanup ? PROTOCOL_CLEANUP_MAX_BLOCK_BASE_SIZE : MAX_BLOCK_BASE_SIZE;
+    const std::size_t max_block_base_size = (rules & SIZE_EXPANSION) ? SIZE_EXPANSION_MAX_BLOCK_BASE_SIZE : MAX_BLOCK_BASE_SIZE;
     if (block.vtx.empty() || block.vtx.size() > max_block_base_size || ::GetSerializeSize(block, SER_NETWORK, PROTOCOL_VERSION | SERIALIZE_TRANSACTION_NO_WITNESS | SERIALIZE_BLOCK_NO_AUX_POW) > max_block_base_size)
         return state.DoS(100, false, REJECT_INVALID, "bad-blk-length", false, "size limits failed");
 
@@ -3713,7 +3721,7 @@ bool CheckBlock(const CBlock& block, CValidationState& state, const Consensus::P
 
     // Check transactions
     BOOST_FOREACH(const CTransaction& tx, block.vtx)
-        if (!CheckTransaction(tx, state, protocol_cleanup))
+        if (!CheckTransaction(tx, state, rules))
             return state.Invalid(false, state.GetRejectCode(), state.GetRejectReason(),
                                  strprintf("Transaction check failed (tx hash %s) %s", tx.GetHash().ToString(), state.GetDebugMessage()));
 
@@ -3722,7 +3730,7 @@ bool CheckBlock(const CBlock& block, CValidationState& state, const Consensus::P
     {
         nSigOps += GetLegacySigOpCount(tx);
     }
-    if (!protocol_cleanup && (nSigOps * WITNESS_SCALE_FACTOR > MAX_BLOCK_SIGOPS_COST))
+    if (!(rules & PROTOCOL_CLEANUP) && (nSigOps * WITNESS_SCALE_FACTOR > MAX_BLOCK_SIGOPS_COST))
         return state.DoS(100, false, REJECT_INVALID, "bad-blk-sigops", false, "out-of-bounds SigOpCount");
 
     if (fCheckPOW && fCheckMerkleRoot)
@@ -3840,19 +3848,19 @@ void GenerateCoinbaseCommitment(CBlock& block, const CBlockIndex* pindexPrev, co
 bool ContextualCheckBlockHeader(const CBlockHeader& block, CValidationState& state, const Consensus::Params& consensusParams, CBlockIndex * const pindexPrev, int64_t nAdjustedTime)
 {
     // Check for activation of rule changes
-    const bool protocol_cleanup = IsProtocolCleanupActive(consensusParams, pindexPrev);
+    const RuleSet rules = GetActiveRules(consensusParams, pindexPrev);
 
     // Check proof of work
-    if (protocol_cleanup ? !CheckNextWorkRequired(pindexPrev, block, consensusParams) : (block.nBits != GetNextWorkRequired(pindexPrev, &block, consensusParams, protocol_cleanup)))
+    if ((rules & PROTOCOL_CLEANUP) ? !CheckNextWorkRequired(pindexPrev, block, consensusParams) : (block.nBits != GetNextWorkRequired(pindexPrev, &block, consensusParams, rules)))
         return state.DoS(100, false, REJECT_INVALID, "bad-diffbits", false, "incorrect proof of work");
 
     if (!block.m_aux_pow.IsNull()) {
-        if (protocol_cleanup ? !CheckNextWorkRequiredAux(pindexPrev, block, consensusParams) : (block.m_aux_pow.m_commit_bits != GetNextWorkRequiredAux(pindexPrev, block, consensusParams))) {
+        if ((rules & SIZE_EXPANSION) ? !CheckNextWorkRequiredAux(pindexPrev, block, consensusParams) : (block.m_aux_pow.m_commit_bits != GetNextWorkRequiredAux(pindexPrev, block, consensusParams))) {
             return state.DoS(100, false, REJECT_INVALID, "bad-aux-diffbits", false, "incorrect auxiliary proof of work target");
         }
 
         // Check committed filter value
-        if (!protocol_cleanup && block.GetFilteredTime() != GetFilteredTimeAux(pindexPrev, consensusParams)) {
+        if (!(rules & SIZE_EXPANSION) && block.GetFilteredTime() != GetFilteredTimeAux(pindexPrev, consensusParams)) {
             return state.DoS(100, false, REJECT_INVALID, "bad-aux-filter-time", false, "incorrect filtered time commitment");
         }
     }
@@ -3867,7 +3875,7 @@ bool ContextualCheckBlockHeader(const CBlockHeader& block, CValidationState& sta
 
     // Reject outdated version blocks when 95% (75% on testnet) of the network has upgraded:
     for (int32_t version = 2; version < 4; ++version) // check for version 2 and 3 upgrades
-        if (!protocol_cleanup && block.nVersion < version && IsSuperMajority(version, pindexPrev, consensusParams.nMajorityRejectBlockOutdated, consensusParams))
+        if (!(rules & PROTOCOL_CLEANUP) && block.nVersion < version && IsSuperMajority(version, pindexPrev, consensusParams.nMajorityRejectBlockOutdated, consensusParams))
             return state.Invalid(false, REJECT_OBSOLETE, strprintf("bad-version(0x%08x)", version - 1),
                                  strprintf("rejected nVersion=0x%08x block", version - 1));
 
@@ -3898,7 +3906,7 @@ bool ContextualCheckBlock(const CBlock& block, CValidationState& state, CBlockIn
     const Consensus::Params& consensusParams = Params().GetConsensus();
 
     // Check for activation of rule changes
-    const bool protocol_cleanup = IsProtocolCleanupActive(consensusParams, pindexPrev);
+    const RuleSet rules = GetActiveRules(consensusParams, pindexPrev);
 
     // Start enforcing BIP113 (Median Time Past) using versionbits logic.
     int nLockTimeFlags = 0;
@@ -3911,7 +3919,7 @@ bool ContextualCheckBlock(const CBlock& block, CValidationState& state, CBlockIn
                               : block.GetBlockTime();
 
     // Check that the coinbase is finalized
-    if (!protocol_cleanup) {
+    if (!(rules & PROTOCOL_CLEANUP)) {
         if (!block.vtx.empty() && !IsFinalTx(block.vtx[0], nHeight, nLockTimeCutoff)) {
             return state.DoS(10, error("%s: coinbase nSequence is non-final", __func__), REJECT_INVALID, "bad-txns-nonfinal");
         }
@@ -3927,7 +3935,7 @@ bool ContextualCheckBlock(const CBlock& block, CValidationState& state, CBlockIn
 
     // Enforce block.nVersion=2 rule that the coinbase starts with serialized block height
     // if 750 of the last 1,000 blocks are version 2 or greater (51/100 if testnet):
-    if (!protocol_cleanup && (block.nVersion >= 2 && IsSuperMajority(2, pindexPrev, consensusParams.nMajorityEnforceBlockUpgrade, consensusParams)))
+    if (!(rules & PROTOCOL_CLEANUP) && (block.nVersion >= 2 && IsSuperMajority(2, pindexPrev, consensusParams.nMajorityEnforceBlockUpgrade, consensusParams)))
     {
         CScript expect = CScript() << nHeight;
         if (block.vtx[0].vin[0].scriptSig.size() < expect.size() ||
@@ -4002,7 +4010,7 @@ bool ContextualCheckBlock(const CBlock& block, CValidationState& state, CBlockIn
     // large by filling up the coinbase witness, which doesn't change
     // the block hash, so we couldn't mark the block as permanently
     // failed).
-    if (GetBlockWeight(block) > (protocol_cleanup ? PROTOCOL_CLEANUP_MAX_BLOCK_WEIGHT : MAX_BLOCK_WEIGHT)) {
+    if (GetBlockWeight(block) > ((rules & SIZE_EXPANSION) ? SIZE_EXPANSION_MAX_BLOCK_WEIGHT : MAX_BLOCK_WEIGHT)) {
         return state.DoS(100, error("ContextualCheckBlock(): weight limit failed"), REJECT_INVALID, "bad-blk-weight");
     }
 
@@ -4757,9 +4765,9 @@ bool LoadExternalBlockFile(const CChainParams& chainparams, FILE* fileIn, CDiskB
     static std::multimap<uint256, CDiskBlockPos> mapBlocksUnknownParent;
     int64_t nStart = GetTimeMillis();
 
-    // If the protocol cleanup fork has activated, then we should
+    // If the size expansion fork has activated, then we should
     // allow importing blocks larger than than the old MAX_BLOCK_SIZE.
-    const bool protocol_cleanup = IsProtocolCleanupActive(chainparams.GetConsensus(), GetAdjustedTime());
+    const bool size_expansion = IsSizeExpansionActive(chainparams.GetConsensus(), GetAdjustedTime());
 
     int nLoaded = 0;
     try {
@@ -4783,7 +4791,7 @@ bool LoadExternalBlockFile(const CChainParams& chainparams, FILE* fileIn, CDiskB
                     continue;
                 // read size
                 blkdat >> nSize;
-                if (nSize < 80 || nSize > (protocol_cleanup ? PROTOCOL_CLEANUP_MAX_BLOCK_SERIALIZED_SIZE : MAX_BLOCK_SERIALIZED_SIZE))
+                if (nSize < 80 || nSize > (size_expansion ? SIZE_EXPANSION_MAX_BLOCK_SERIALIZED_SIZE : MAX_BLOCK_SERIALIZED_SIZE))
                     continue;
             } catch (const std::exception&) {
                 // no valid block header found; don't complain

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3851,7 +3851,7 @@ bool ContextualCheckBlockHeader(const CBlockHeader& block, CValidationState& sta
     const RuleSet rules = GetActiveRules(consensusParams, pindexPrev);
 
     // Check proof of work
-    if ((rules & PROTOCOL_CLEANUP) ? !CheckNextWorkRequired(pindexPrev, block, consensusParams) : (block.nBits != GetNextWorkRequired(pindexPrev, &block, consensusParams, rules)))
+    if (!(rules & PROTOCOL_CLEANUP) && (block.nBits != GetNextWorkRequired(pindexPrev, &block, consensusParams)))
         return state.DoS(100, false, REJECT_INVALID, "bad-diffbits", false, "incorrect proof of work");
 
     if (!block.m_aux_pow.IsNull()) {

--- a/src/main.h
+++ b/src/main.h
@@ -27,6 +27,7 @@
 #include "amount.h"
 #include "chain.h"
 #include "coins.h"
+#include "consensus/consensus.h"
 #include "net.h"
 #include "script/script_error.h"
 #include "sync.h"
@@ -162,153 +163,231 @@ static const bool DEFAULT_PEERBLOOMFILTERS = true;
 
 /** Scheduled protocol cleanup rule change
  **
- ** To achieve desired scaling limits, the forward blocks architecture
- ** will eventually trigger a hard-fork modification of the consensus
- ** rules, for the primary purpose of dropping enforcement of many
- ** aggregate block limits and altering the difficulty adjustment
- ** algorithm.
+ ** Merge mining is implemented as a soft-fork change to the consensus rules to
+ ** achieve a safer and less-disruptive deployment than the hard-fork that was
+ ** used to deploy merge mining to other chains in the past: non-upgraded
+ ** clients will continue to receive blocks at the point of activation with SPV
+ ** security.  However the security of successive blocks will diminish as the
+ ** difficulty transitions from native to auxiliary proof-of-work.  When the
+ ** native difficulty reaches minimal values, there will no longer be any
+ ** effective SPV protections for old nodes, and this represents a unique
+ ** opportunity to deploy other non-controversial hard-fork changes to the
+ ** consensus rules.
  **
- ** This hard-fork will not activate until it is absolutely necessary
- ** for it to do so, at the point when real demand for additional
- ** shard space in aggregate across all forward block shard-chains
- ** exceeds the available space in the compatibility chain. It is
- ** anticipated that this will not occur until many, many years into
- ** the future, when Freicoin/Tradecraft's usage exceeds even the
- ** levels of bitcoin usage ca. 2018. However when it does eventually
- ** trigger, any node enforcing the old rules will be left behind.
+ ** For this reason, a protocol-cleanup hard-fork is scheduled to take place
+ ** after the activation of merge mining and difficulty transition.  As part of
+ ** this cleanup, the following consensus rule changes will take effect:
  **
- ** Since the rule changes for forward blocks have not been written
- ** yet and becauses this flag-day code doesn't know how to detect
- ** actual activation, we cannot have older clients enforce the new
- ** rules. What is done instead is that any rule which we anticipate
- ** changes becomes simply unenforced after this activation time, and
- ** aggregate limits are set to the maximum values the software is
- ** able to support. After the flag-day, older clients of at least
- ** version 10.4 will continue to receive blocks, but with only SPV
- ** security ("trust the most work") for the new protocol rules. So
- ** starting with the release of v10.4-7842, activation of forward
- ** blocks new scaling limits becomes a soft-fork, with the only
- ** concern being the forking off of 0.9 series and earlier nodes upon
- ** activation.
+ **   1. Remove the native proof-of-work requirement entirely.  For reasons of
+ **      infrastructure compatibility the block hash will still be the hash of
+ **      the native header, but the hash of the header will no longer have to
+ **      meet any threshold target.  This makes a winning auxiliary share
+ **      automatically a winning block.
  **
- ** The primary rules which must be altered for forward blocks scaling
- ** are:
+ **   2. Remove the MAX_BLOCK_SIGOPS_COST limit.  Switching to libsecp256k1 for
+ **      validation and better signature / script and transaction validation
+ **      caching has made this limit nearly redundant.
  **
- **   1. Significant relaxation of the rules regarding per-block
- **      difficulty adjustment, to allow adjustments of +/- 2x within
- **      twelve blocks, without regard of a target interval. Forward
- **      blocks will have a new difficulty adjustment algorithm that
- **      has yet to be determined, and will include adjusting to a
- **      variable inter-block time to achieve compatability chain
- **      scalability.
+ **   3. Allow a transaction without transaction outputs.  A transaction must
+ **      have input(s) to have a unique transaction ID, but it need not have
+ **      outputs.  There are obscure cases when this makes sense to do (and thus
+ **      forward the funds entirely as "fee" to the miner, or to process in the
+ **      block-final transaction and/or coinbase in some way).
  **
- **   2. Increase of the maximum block size. Uncapping the block size
- **      is not possible because even if the explicit limit is removed
- **      there are still implicit network and disk protocol limits
- **      that would prevent a client from syncing a chain with larger
- **      blocks. But these network and disk limits could be set much
- **      higher than the current limits based on a 1 megabyte
- **      MAX_BASE_BLOCK_SIZE / 4 megaweight MAX_BLOCK_WEIGHT.
- **
- **   3. Allow larger transactions, up to the new, larger maximum
- **      block size limit in size. This is less safe than increasing
- **      the block size since most of the quadratic validation costs
- **      are only quadratic in transaction size. But there is research
- **      to be done in choosing what new limits should be used, and in
- **      the mean time keeping transactions only limited by the (new)
- **      block size permits flexibility in that future choice.
- **
- ** That is all that MUST be done, but there are a number of other
- ** rule changes that are related, or are trivial to accomplish at the
- ** same time. These include:
- **
- **   4. Removal of MAX_BLOCK_SIGOPS_COST limit. Switching to
- **      libsecp256k1 for validation and better signature / script and
- **      transaction validation caching has made this limit nearly
- **      redundant.
- **
- **   5. Allow a transaction without transaction outputs. A
- **      transaction must have inputs to have a unique transactionn
- **      ID, but it need not have outputs. There are obscure cases
- **      when this makes sense to do (and thus forward the funds
- **      entirely as "fee" to the miner, to process in the coinbase in
- **      some way).
- **
- **   6. Do not restrict the contents of the "coinbase string" in any
- **      way. It is currently required to be between 2 and 100 bytes
- **      in size, and must begin with the serialized block height. The
- **      length restriction is unnecesary as miners have other means
- **      of padding transactions if they need to, and are generally
- **      incentivised not to because of miner fees. The serialized
- **      height requirement is redundant as lock_height is also
+ **   4. Do not restrict the contents of the "coinbase string" in any way,
+ **      beyond the required auxiliary proof-of-work commitment.  It is
+ **      currently required to be between 2 and 100 bytes in size, and must
+ **      begin with the serialized block height.  The length restriction is
+ **      unnecessary as miners have other means of padding transactions if they
+ **      need to, and are generally incentivized not to because of miner fees.
+ **      The serialized height requirement is redundant as lock_height is also
  **      required to be set to the current block height.
  **
- **   7. Reduce coinbase maturity to 1 block. Once forward blocks has
- **      activated, coinbase maturity is an unnecessary delay to
- **      processing the coinbase payout queue. It must be at least 1
- **      to prevent miners from issuing themselves excess funds for
- **      the duration of 1 block.
+ **   5. Do not require the coinbase transaction to be final, freeing up
+ **      nSequence to be used as the miner's extranonce field.  A previous
+ **      soft-fork which required the coinbase's nLockTime field to be set to
+ **      the medium-time-past value had the unfortunate side effect of requiring
+ **      nSequence to be set to 0xffffffff since even the coinbase is checked
+ **      for transaction finality.  The concept of finality makes no sense for
+ **      the coinbase and this requirement is dropped after activation of the
+ **      new rules, making the 4-byte nSquence field have no consensus-defined
+ **      meaning, allowing it to be used as an extrnonce field.
  **
- **   8. Do not require zero-valued outputs to be spent by
- **      transactions with lock_height >= the coin's refheight. This
- **      restriction ensured that refheights were always increasing so
- **      that demurrage is collected, not reversed. However this
- **      argument doesn't really make sense for zero-valued outputs.
- **      At the same time "zero-valued" outputs are increasingly
- **      likely to be used for confidential or non-freicoin assets
- **      using extension outputs, for which monotonic lock_heights are
- **      just an annoying protocol complication.
+ **   6. Do not require zero-valued outputs to be spent by transactions with
+ **      lock_height >= the coin's refheight.  This restriction is to ensure
+ **      that refheights are always increasing so that demurrage is collected,
+ **      not reversed.  However this argument doesn't really make sense for
+ **      zero-valued outputs.  At the same time "zero-valued" outputs are
+ **      increasingly likely to be used for confidential transactions or
+ **      non-freicoin issued assets using extension outputs, for which the
+ **      monotonic lock_height requirement is just an annoying protocol
+ **      complication.
  **
- **   9. Do not reject "old" blocks after activation of the nVersion=2
- **      and nVersion=3 soft-forks. With the switch to version bits
- **      for soft-fork activation, this archaic check is shown to be
- **      rather pointless. Rules are enforced in a block if it is
- **      downstream of the point of activation, not based on the
- **      nVersion value.  Implicitly this also restores validity of
- **      "negative" block.nVersion values.
+ **   7. Do not reject "old" blocks after activation of the nVersion=2 and
+ **      nVersion=3 soft-forks.  With the switch to version bits for soft-fork
+ **      activation, this archaic check is shown to be rather pointless.  Rules
+ **      are enforced in a block if it is downstream of the point of activation,
+ **      not based on the nVersion value.  Implicitly this also restores
+ **      validity of "negative" block.nVersion values.
  **
- **   10. Lift restrictions inside the script interpreter on maximum
- **       script size, maximum data push, maximum number of elements
- **       on the stack, and maximum number of executed opcodes.
+ **   8. Lift restrictions inside the script interpreter on maximum script size,
+ **      maximum data push, maximum number of elements on the stack, and maximum
+ **      number of executed opcodes.
  **
- **   11. Remove checks on disabled opcodes, and cause unrecognized
- **       opcodes to "return true" instead of raising an error.
+ **   9. Remove checks on disabled opcodes, and cause unrecognized opcodes to
+ **      "return true" instead of raising an error.
  **
- **   12. Re-enable (and implement) certain disabled opcodes, and
- **       conspiciously missing opcodes which were never there in the
- **       first place.
+ **   10. Re-enable (and implement) certain disabled opcodes, and conspicuously
+ **       missing opcodes which were never there in the first place.
  **
- ** These consensus rules are eliminated or significantly relaxed at
- ** the same time as the aggregate limits are removed, hence the
- ** general label a "protocol cleanup" fork.
+ ** Activation of the protocol-cleanup fork depends on the median-time-past of
+ ** the tip relative to a consensus parameter.  While it makes more logical
+ ** sense for this to be an inline method of the chain parameters, doing so
+ ** would introduce a new dependency on CBlockIndex there.
  **
- ** Activation of the protocol-cleanup fork depends on the
- ** median-time-past of the tip relative to a consensus parameter.
- ** While it makes more logical sense for this to be an inline method
- ** of the chain parameters, doing so would introduce a new dependency
- ** on CBlockIndex there.
- **
- ** There are two implementations that appear to do different things,
- ** but actually are making the same check. The median-time-past is
- ** stored in the coinbase of the block within the nLockTime field,
- ** which allows this check to be made at points where no chain
- ** context is available.
+ ** There are two implementations that appear to do different things, but
+ ** actually are making the same check.  The median-time-past is stored in the
+ ** coinbase of the block within the nLockTime field, which allows this check to
+ ** be made at points where no chain context is available.
  **/
 inline bool IsProtocolCleanupActive(const Consensus::Params& params, const CBlock& block)
 {
+    if (block.m_aux_pow.IsNull()) {
+        return false;
+    }
     return ((!block.vtx.empty() ? block.vtx[0].nLockTime : 0) >= params.protocol_cleanup_activation_time);
 }
 inline bool IsProtocolCleanupActive(const Consensus::Params& params, const CBlockIndex* pindex)
 {
+    if (!pindex || pindex->m_aux_pow.IsNull()) {
+        return false;
+    }
     return ((pindex ? pindex->GetMedianTimePast() : 0) >= params.protocol_cleanup_activation_time);
 }
-/** Finally, a version based on network time, for places in
- ** non-consensus code where it would be inappropriate to examine the
- ** chain tip.
+
+/** Scheduled size expansion rule change
+ **
+ ** To achieve desired scaling limits, the forward blocks architecture will
+ ** eventually trigger a hard-fork modification of the consensus rules, for the
+ ** primary purpose of dropping enforcement of many aggregate block limits so as
+ ** to allow larger blocks on the compatibility chain.
+ **
+ ** This hard-fork will not activate until it is absolutely necessary for it to
+ ** do so, at the point when real demand for additional shard space in aggregate
+ ** across all forward block shard-chains exceeds the available space in the
+ ** compatibility chain.  It is anticipated that this will not occur until many,
+ ** many years into the future, when Freicoin/Tradecraft's usage exceeds even
+ ** the levels of bitcoin usage ca. 2018.  However when it does eventually
+ ** trigger, any node enforcing the old rules will be left behind.
+ **
+ ** Since the rule changes for forward blocks have not been written yet and
+ ** because this flag-day code doesn't know how to detect actual activation, we
+ ** cannot have older clients enforce the new rules.  What is done instead is
+ ** that any rule which we anticipate changing becomes simply unenforced after
+ ** this activation time, and aggregate limits are set to the maximum values the
+ ** software is able to support.  After the flag-day, older clients of at least
+ ** version 13.2.4 will continue to receive blocks, but with only SPV security
+ ** ("trust the most work") for the new protocol rules.  So starting with the
+ ** release of v13.2.4-?????, activation of forward blocks' new scaling limits
+ ** becomes a soft-fork, with the only concern being the forking off of older
+ ** nodes upon activation.
+ **
+ ** The primary rules which must be altered for forward blocks scaling are:
+ **
+ **   1. Significant relaxation of the rules regarding per-block auxiliary
+ **      difficulty adjustment, to allow adjustments of +/- 2x within eleven
+ **      blocks, without regard of a target interval.  Forward blocks may have a
+ **      new difficulty adjustment algorithm that has yet to be determined, and
+ **      might include targeting a variable inter-block time to achieve
+ **      compatibility chain scalability.
+ **
+ **   2. Increase of the maximum block size.  Uncapping the block size is not
+ **      possible because even if the explicit limit is removed there are still
+ **      implicit network and disk protocol limits that would prevent a client
+ **      from syncing a chain with larger blocks.  But these network and disk
+ **      limits could be set much higher than the current limits based on a 1
+ **      megabyte MAX_BASE_BLOCK_SIZE / 4 megaweight MAX_BLOCK_WEIGHT.
+ **
+ **   3. Allow larger transactions, up to the new, larger maximum block size
+ **      limit in size.  This is less safe than increasing the block size since
+ **      most of the nonlinear validation costs are quadratic in transaction
+ **      size.  But there is research to be done in choosing what new limits
+ **      should be used, and in the mean time keeping transactions only limited
+ **      by the (new) block size permits flexibility in that future choice.
+ **
+ **   4. Reduce coinbase maturity to 1 block.  Once forward blocks has
+ **      activated, coinbase maturity is an unnecessary delay to processing the
+ **      coinbase payout queue.  It must be at least 1 to prevent miners from
+ **      issuing themselves excess funds for the duration of 1 block.
+ **
+ ** Since we don't know when forward blocks will be deployed and activated, we
+ ** schedule these rule changes to occur at the end of the support window for
+ ** each client release, which is typically 2 years.  Each new release pushes
+ ** back this activation date, and since the new rules are a relaxation of the
+ ** old rules older clients will remain compatible so long as a majority of
+ ** miners have upgrade and thereby pushed back their activation dates.  When
+ ** forward blocks is finally deployed and activated, it will schedule its own
+ ** modified rule relaxation to occur after the most distant flag day.
+ **/
+inline bool IsSizeExpansionActive(const Consensus::Params& params, const CBlock& block)
+{
+    if (block.m_aux_pow.IsNull()) {
+        return false;
+    }
+    return ((!block.vtx.empty() ? block.vtx[0].nLockTime : 0) >= params.size_expansion_activation_time);
+}
+inline bool IsSizeExpansionActive(const Consensus::Params& params, const CBlockIndex* pindex)
+{
+    if (!pindex || pindex->m_aux_pow.IsNull()) {
+        return false;
+    }
+    return ((pindex ? pindex->GetMedianTimePast() : 0) >= params.size_expansion_activation_time);
+}
+
+inline RuleSet GetActiveRules(const Consensus::Params& params, const CBlock& block)
+{
+    RuleSet rules = 0;
+    if (IsProtocolCleanupActive(params, block)) {
+        rules |= PROTOCOL_CLEANUP;
+    }
+    if (IsSizeExpansionActive(params, block)) {
+        rules |= SIZE_EXPANSION;
+    }
+    return rules;
+}
+inline RuleSet GetActiveRules(const Consensus::Params& params, const CBlockIndex* pindex)
+{
+    RuleSet rules = 0;
+    if (IsProtocolCleanupActive(params, pindex)) {
+        rules |= PROTOCOL_CLEANUP;
+    }
+    if (IsSizeExpansionActive(params, pindex)) {
+        rules |= SIZE_EXPANSION;
+    }
+    return rules;
+}
+
+/** A version based on network time, for places in non-consensus code
+ ** where it would be inappropriate to examine the chain tip.
  **/
 inline bool IsProtocolCleanupActive(const Consensus::Params& params, int64_t now)
 {
-    return (now > (params.protocol_cleanup_activation_time - 2*60*60 /* two hours */));
+    return (now > (params.protocol_cleanup_activation_time - 3*60*60 /* three hours */));
+}
+inline bool IsSizeExpansionActive(const Consensus::Params& params, int64_t now)
+{
+    return (now > (params.size_expansion_activation_time - 3*60*60 /* three hours */));
+}
+inline RuleSet GetActiveRules(const Consensus::Params& params, int64_t now)
+{
+    RuleSet rules = 0;
+    if (IsProtocolCleanupActive(params, now)) {
+        rules |= PROTOCOL_CLEANUP;
+    }
+    if (IsSizeExpansionActive(params, now)) {
+        rules |= SIZE_EXPANSION;
+    }
+    return rules;
 }
 
 struct BlockHasher
@@ -528,7 +607,7 @@ bool CheckInputs(const CTransaction& tx, CValidationState &state, const CCoinsVi
 void UpdateCoins(const CTransaction& tx, CCoinsViewCache& inputs, int nHeight);
 
 /** Context-independent validity checks */
-bool CheckTransaction(const CTransaction& tx, CValidationState& state, bool protocol_cleanup);
+bool CheckTransaction(const CTransaction& tx, CValidationState& state, RuleSet rules);
 
 /**
  * Check if transaction is final and can be included in a block with the

--- a/src/merkleblock.cpp
+++ b/src/merkleblock.cpp
@@ -169,7 +169,7 @@ uint256 CPartialMerkleTree::ExtractMatches(std::vector<uint256> &vMatch, std::ve
     if (nTransactions == 0)
         return uint256();
     // check for excessively high numbers of transactions
-    if (nTransactions > PROTOCOL_CLEANUP_MAX_BLOCK_BASE_SIZE / 60) // 60 is the lower bound for the size of a serialized CTransaction
+    if (nTransactions > SIZE_EXPANSION_MAX_BLOCK_BASE_SIZE / 60) // 60 is the lower bound for the size of a serialized CTransaction
         return uint256();
     // there can never be more hashes provided than one for every txid
     if (vHash.size() > nTransactions)

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -260,7 +260,7 @@ CBlockTemplate* BlockAssembler::CreateNewBlock(const CScript& scriptPubKeyIn)
     // Fill in header
     pblock->hashPrevBlock  = pindexPrev->GetBlockHash();
     UpdateTime(pblock, chainparams.GetConsensus(), pindexPrev);
-    pblock->nBits          = GetNextWorkRequired(pindexPrev, pblock, chainparams.GetConsensus(), false);
+    pblock->nBits          = GetNextWorkRequired(pindexPrev, pblock, chainparams.GetConsensus());
     pblock->nNonce         = 0;
     pblocktemplate->vTxSigOpsCost[0] = WITNESS_SCALE_FACTOR * GetLegacySigOpCount(pblock->vtx[0]);
 

--- a/src/pow.cpp
+++ b/src/pow.cpp
@@ -130,7 +130,7 @@ std::pair<int64_t, int64_t> GetFilteredAdjustmentFactor(const CBlockIndex* pinde
     return std::make_pair(numerator, denominator);
 }
 
-unsigned int GetNextWorkRequired(const CBlockIndex* pindexLast, const CBlockHeader *pblock, const Consensus::Params& params, bool protocol_cleanup)
+unsigned int GetNextWorkRequired(const CBlockIndex* pindexLast, const CBlockHeader *pblock, const Consensus::Params& params, RuleSet rules)
 {
     unsigned int nProofOfWorkLimit = UintToArith256(params.powLimit).GetCompact();
 
@@ -146,7 +146,7 @@ unsigned int GetNextWorkRequired(const CBlockIndex* pindexLast, const CBlockHead
 
     // If we are past the protocol-cleanup fork, then the minimum proof-of-work
     // becomes something easily calculable.
-    if (protocol_cleanup) {
+    if (rules & PROTOCOL_CLEANUP) {
         nProofOfWorkLimit = 0x207fffff;
     }
 
@@ -159,10 +159,10 @@ unsigned int GetNextWorkRequired(const CBlockIndex* pindexLast, const CBlockHead
         return pindexLast->nBits;
     }
 
-    return CalculateNextWorkRequired(pindexLast, params, protocol_cleanup);
+    return CalculateNextWorkRequired(pindexLast, params, rules);
 }
 
-unsigned int CalculateNextWorkRequired(const CBlockIndex* pindexLast, const Consensus::Params& params, bool protocol_cleanup)
+unsigned int CalculateNextWorkRequired(const CBlockIndex* pindexLast, const Consensus::Params& params, RuleSet rules)
 {
     if (params.fPowNoRetargeting)
         return pindexLast->nBits;
@@ -181,7 +181,7 @@ unsigned int CalculateNextWorkRequired(const CBlockIndex* pindexLast, const Cons
     assert(adjustment_factor.second > 0);
 
     // Retarget
-    arith_uint256 bnPowLimit = UintToArith256(protocol_cleanup ? k_min_pow_limit : params.powLimit);
+    arith_uint256 bnPowLimit = UintToArith256((rules & PROTOCOL_CLEANUP) ? k_min_pow_limit : params.powLimit);
     arith_uint256 bnNew;
     bnNew.SetCompact(pindexLast->nBits);
     arith_uint320 bnTmp(bnNew);

--- a/src/pow.cpp
+++ b/src/pow.cpp
@@ -130,9 +130,9 @@ std::pair<int64_t, int64_t> GetFilteredAdjustmentFactor(const CBlockIndex* pinde
     return std::make_pair(numerator, denominator);
 }
 
-unsigned int GetNextWorkRequired(const CBlockIndex* pindexLast, const CBlockHeader *pblock, const Consensus::Params& params, RuleSet rules)
+unsigned int GetNextWorkRequired(const CBlockIndex* pindexLast, const CBlockHeader *pblock, const Consensus::Params& params)
 {
-    unsigned int nProofOfWorkLimit = UintToArith256(params.powLimit).GetCompact();
+    static const unsigned int nProofOfWorkLimit = UintToArith256(params.powLimit).GetCompact();
 
     // Genesis block
     if (pindexLast == NULL)
@@ -144,12 +144,6 @@ unsigned int GetNextWorkRequired(const CBlockIndex* pindexLast, const CBlockHead
     if (pindexLast->GetBlockHash() == uint256S("0x0000000000003bd73ea13954fbbf1cf50b5384f961d142a75a3dfe106f793a20"))
         return 0x1b01c13a;
 
-    // If we are past the protocol-cleanup fork, then the minimum proof-of-work
-    // becomes something easily calculable.
-    if (rules & PROTOCOL_CLEANUP) {
-        nProofOfWorkLimit = 0x207fffff;
-    }
-
     const bool use_filter = (pindexLast->nHeight >= (params.diff_adjust_threshold - 1));
     const int64_t interval = use_filter ? params.filtered_adjust_interval : params.original_adjust_interval;
 
@@ -159,10 +153,10 @@ unsigned int GetNextWorkRequired(const CBlockIndex* pindexLast, const CBlockHead
         return pindexLast->nBits;
     }
 
-    return CalculateNextWorkRequired(pindexLast, params, rules);
+    return CalculateNextWorkRequired(pindexLast, params);
 }
 
-unsigned int CalculateNextWorkRequired(const CBlockIndex* pindexLast, const Consensus::Params& params, RuleSet rules)
+unsigned int CalculateNextWorkRequired(const CBlockIndex* pindexLast, const Consensus::Params& params)
 {
     if (params.fPowNoRetargeting)
         return pindexLast->nBits;
@@ -181,7 +175,7 @@ unsigned int CalculateNextWorkRequired(const CBlockIndex* pindexLast, const Cons
     assert(adjustment_factor.second > 0);
 
     // Retarget
-    arith_uint256 bnPowLimit = UintToArith256((rules & PROTOCOL_CLEANUP) ? k_min_pow_limit : params.powLimit);
+    arith_uint256 bnPowLimit = UintToArith256(params.powLimit);
     arith_uint256 bnNew;
     bnNew.SetCompact(pindexLast->nBits);
     arith_uint320 bnTmp(bnNew);
@@ -193,54 +187,6 @@ unsigned int CalculateNextWorkRequired(const CBlockIndex* pindexLast, const Cons
         bnNew = bnPowLimit;
 
     return bnNew.GetCompact();
-}
-
-// Called after activation of the protocol-cleanup rule changes, at
-// which time the difficulty adjustment is largely unchecked. For DoS
-// prevention purposes we require that the difficulty adjust by no
-// more than +/- 2x as compared with the difficulties of the last 12
-// blocks. This is enough of a constraint that any DoS attack is
-// forced to have non-trivial mining costs (e.g. equal to extending
-// the tip by 6 blocks to reduce difficulty by more than a half, work
-// equal to extending the tip by 9 blocks to reduce by more than a
-// quarter, 10.5 times present difficulty to reduce by more than an
-// eigth, etc. To reduce to arbitrary levels requires 12 blocks worth
-// of work at the difficulty of the last valid block.
-bool CheckNextWorkRequired(const CBlockIndex* pindexLast, const CBlockHeader& block, const Consensus::Params& params)
-{
-    // Special case for the genesis block
-    if (!pindexLast) {
-        return (block.nBits == UintToArith256(params.powLimit).GetCompact());
-    }
-
-    // If these look reversed, that is to be expected. We set min to
-    // the largest possible value, and max to the smallest.  That way
-    // these will be replaced with actual block values as we loop
-    // through the past 12 blocks.
-    arith_uint256 min = UintToArith256(params.powLimit);
-    arith_uint256 max = arith_uint256(1);
-
-    // After this loop, min will be half the largest work target of
-    // the past 12 blocks, and max will be twice the smallest.
-    for (int i = 0; i < 12 && pindexLast; ++i, pindexLast = pindexLast->pprev) {
-        arith_uint256 target;
-        target.SetCompact(pindexLast->nBits);
-        arith_uint256 local_min = target >> 1;
-        arith_uint256 local_max = target << 1;
-        if (min > local_min) {
-            min = local_min;
-        }
-        if (max < local_max) {
-            max = local_max;
-        }
-    }
-
-    // See if the passed in block's nBits specifies a target within
-    // the range of half to twice the work targets of the past 12
-    // blocks, inclusive of the endpoints.
-    arith_uint256 target;
-    target.SetCompact(block.nBits);
-    return ((min <= target) && (target <= max));
 }
 
 int64_t GetFilteredTimeAux(const CBlockIndex* pindexLast, const Consensus::Params& params)
@@ -390,6 +336,16 @@ uint32_t CalculateNextWorkRequiredAux(const CBlockIndex* pindexLast, const Conse
     return ((new_target > pow_limit) ? pow_limit : new_target).GetCompact();
 }
 
+// Called after activation of the size-expansion rule changes, at which time the
+// difficulty adjustment becomes largely unchecked.  For DoS prevention purposes
+// we require that the difficulty adjust by no more than +/- 2x as compared with
+// the difficulties of the last 11 blocks. This is enough of a constraint that
+// any DoS attack is forced to have non-trivial mining costs (e.g. equal to
+// extending the tip by 6 blocks to reduce difficulty by more than a half, work
+// equal to extending the tip by 9 blocks to reduce by more than a quarter, 10.5
+// times present difficulty to reduce by more than an eigth, etc.  To reduce to
+// arbitrary levels requires a dozen blocks worth of work at the difficulty of
+// the last valid block.
 bool CheckNextWorkRequiredAux(const CBlockIndex* pindexLast, const CBlockHeader& block, const Consensus::Params& params)
 {
     // There's nothing to check before activation of merged mining.
@@ -410,13 +366,13 @@ bool CheckNextWorkRequiredAux(const CBlockIndex* pindexLast, const CBlockHeader&
 
     // If look reversed, that is to be expected. We set min to the largest
     // possible value, and max to the smallest. That way these will be replaced
-    // with actual block values as we loop through the past 12 blocks.
+    // with actual block values as we loop through the past 11 blocks.
     arith_uint256 min = UintToArith256(params.aux_pow_limit);
     arith_uint256 max = arith_uint256(1);
 
     // After this loop, min will be half the largest work target of
-    // the past 12 blocks, and max will be twice the smallest.
-    for (int i = 0; i < 12 && pindexLast && !pindexLast->m_aux_pow.IsNull(); ++i, pindexLast = pindexLast->pprev) {
+    // the past 11 blocks, and max will be twice the smallest.
+    for (int i = 0; i < 11 && pindexLast && !pindexLast->m_aux_pow.IsNull(); ++i, pindexLast = pindexLast->pprev) {
         arith_uint256 target;
         target.SetCompact(pindexLast->m_aux_pow.m_commit_bits);
         arith_uint256 local_min = target >> 1;
@@ -430,7 +386,7 @@ bool CheckNextWorkRequiredAux(const CBlockIndex* pindexLast, const CBlockHeader&
     }
 
     // See if the passed in block's m_commit_bits specifies a target within the
-    // range of half to twice the work targets of the past 12 blocks, inclusive
+    // range of half to twice the work targets of the past 11 blocks, inclusive
     // of the endpoints.
     arith_uint256 target;
     target.SetCompact(block.m_aux_pow.m_commit_bits);

--- a/src/pow.h
+++ b/src/pow.h
@@ -34,15 +34,14 @@ class uint256;
 int64_t GetFilteredTime(const CBlockIndex* pindexLast, const Consensus::Params&);
 int64_t GetFilteredTimeAux(const CBlockIndex* pindexLast, const Consensus::Params&);
 
-unsigned int GetNextWorkRequired(const CBlockIndex* pindexLast, const CBlockHeader *pblock, const Consensus::Params&, RuleSet rules);
-unsigned int CalculateNextWorkRequired(const CBlockIndex* pindexLast, const Consensus::Params&, RuleSet rules);
-
-/** Verify that a block's work target is within the range of half to
- ** twice the targets of the past 12 blocks. */
-bool CheckNextWorkRequired(const CBlockIndex* pindexLast, const CBlockHeader& block, const Consensus::Params&);
+unsigned int GetNextWorkRequired(const CBlockIndex* pindexLast, const CBlockHeader *pblock, const Consensus::Params&);
+unsigned int CalculateNextWorkRequired(const CBlockIndex* pindexLast, const Consensus::Params&);
 
 uint32_t GetNextWorkRequiredAux(const CBlockIndex* pindexLast, const CBlockHeader& block, const Consensus::Params&);
 uint32_t CalculateNextWorkRequiredAux(const CBlockIndex* pindexLast, const Consensus::Params&);
+
+/** Verify that a block's work target is within the range of half to
+ ** twice the targets of the past 12 blocks. */
 bool CheckNextWorkRequiredAux(const CBlockIndex* pindexLast, const CBlockHeader& block, const Consensus::Params&);
 
 /** Check whether a block hash satisfies the proof-of-work requirement specified by nBits */

--- a/src/pow.h
+++ b/src/pow.h
@@ -20,6 +20,7 @@
 #ifndef FREICOIN_POW_H
 #define FREICOIN_POW_H
 
+#include "consensus/consensus.h"
 #include "consensus/params.h"
 
 #include "primitives/block.h"
@@ -33,8 +34,8 @@ class uint256;
 int64_t GetFilteredTime(const CBlockIndex* pindexLast, const Consensus::Params&);
 int64_t GetFilteredTimeAux(const CBlockIndex* pindexLast, const Consensus::Params&);
 
-unsigned int GetNextWorkRequired(const CBlockIndex* pindexLast, const CBlockHeader *pblock, const Consensus::Params&, bool protocol_cleanup);
-unsigned int CalculateNextWorkRequired(const CBlockIndex* pindexLast, const Consensus::Params&, bool protocol_cleanup);
+unsigned int GetNextWorkRequired(const CBlockIndex* pindexLast, const CBlockHeader *pblock, const Consensus::Params&, RuleSet rules);
+unsigned int CalculateNextWorkRequired(const CBlockIndex* pindexLast, const Consensus::Params&, RuleSet rules);
 
 /** Verify that a block's work target is within the range of half to
  ** twice the targets of the past 12 blocks. */

--- a/src/protocol.cpp
+++ b/src/protocol.cpp
@@ -22,6 +22,7 @@
 #include "chainparams.h"
 #include "consensus/consensus.h"
 #include "consensus/params.h"
+#include "main.h"
 #include "timedata.h"
 #include "util.h"
 #include "utilstrencodings.h"
@@ -98,14 +99,14 @@ const static std::vector<std::string> allNetMessageTypesVec(allNetMessageTypes, 
 extern int nMaxConnections; // declared in net.h
 std::size_t MaxProtocolMessageLength(const Consensus::Params &params)
 {
-    // Unconstraining the block size in the protocol cleanup fork
+    // Unconstraining the block size in the size expansion fork
     // means that network message size must also be unconstrained,
     // which is a potential DoS vector. Unfortunately there is no
     // easy way around this. Until better tools are available in
     // future versions, we must accept that after activation of
-    // the protocol cleanup fork we might receive a message up to
+    // the size expansion fork we might receive a message up to
     // the largest possible block size, which is limited only by
-    // PROTOCOL_CLEANUP_MAX_BLOCKFILE_SIZE, which is nearly 2 GiB.
+    // SIZE_EXPANSION_MAX_BLOCKFILE_SIZE, which is nearly 2 GiB.
     //
     // However this value is dangerously high for 32-bit clients,
     // as it presents an easy DoS vector for memory exhaustion
@@ -118,7 +119,7 @@ std::size_t MaxProtocolMessageLength(const Consensus::Params &params)
     // with the network in such an instance, this is deemed an
     // acceptable tradeoff.
     std::size_t max_msg_size = MAX_PROTOCOL_MESSAGE_LENGTH;
-    if (GetAdjustedTime() > (Params().GetConsensus().protocol_cleanup_activation_time - 2*60*60 /* two hours */)) {
+    if (IsSizeExpansionActive(Params().GetConsensus(), GetAdjustedTime())) {
         // Use no more than 2 GiB for messages in flight on 32-bit
         // peers. With the default max of 125 connections this is
         // slightly more than 16 MiB. A 32-bit node operator could
@@ -132,7 +133,7 @@ std::size_t MaxProtocolMessageLength(const Consensus::Params &params)
         // enormous number, so we use the lower implicit protocol
         // rule of the maximum blockfile size--a block larger than
         // this value could not be stored to disk.
-        max_msg_size = std::min(max_data_per_peer, static_cast<std::size_t>(PROTOCOL_CLEANUP_MAX_BLOCK_SERIALIZED_SIZE + 24));
+        max_msg_size = std::min(max_data_per_peer, static_cast<std::size_t>(SIZE_EXPANSION_MAX_BLOCK_SERIALIZED_SIZE + 24));
     }
     return max_msg_size;
 }

--- a/src/script/interpreter.h
+++ b/src/script/interpreter.h
@@ -161,6 +161,13 @@ enum
     SCRIPT_VERIFY_MULTISIG_HINT = (1U << 15),
 
     // Set if we are relaxing some of the overly restrictive protocol
+    // rules as part of the "size expansion" fork. See commet in
+    // main.h for further description. This flag is a bit unlike the
+    // other script verification flags, but it is the easiest way to
+    // pass this parameter around the script validation code.
+    SCRIPT_VERIFY_SIZE_EXPANSION = (1U << 28),
+
+    // Set if we are relaxing some of the overly restrictive protocol
     // rules as part of the "protocol cleanup" fork. See commet in
     // main.h for further description. This flag is a bit unlike the
     // other script verification flags, but it is the easiest way to

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -394,7 +394,7 @@ ReadKeyValue(CWallet* pwallet, CDataStream& ssKey, CDataStream& ssValue,
             CWalletTx wtx;
             ssValue >> wtx;
             CValidationState state;
-            if (!(CheckTransaction(wtx, state, wtx.GetTxTime() >= Params().GetConsensus().protocol_cleanup_activation_time) && (wtx.GetHash() == hash) && state.IsValid()))
+            if (!(CheckTransaction(wtx, state, GetActiveRules(Params().GetConsensus(), wtx.GetTxTime())) && (wtx.GetHash() == hash) && state.IsValid()))
                 return false;
 
             // Undo serialize changes in 31600


### PR DESCRIPTION
There was a previously scheduled "protocol cleanup" hard-fork which would have provided a number of navel-gazing fixes to the consensus rules when it activates, in 2022 at the earliest, as well as relaxing the aggregate block and transaction limits.  The switch to merge mining, however, presents a unique opportunity to have an accelerated hard-fork schedule. This PR therefore splits the previous hard-fork into two separate rule relaxation events, the non-controversial protocol-cleanup fixes scheduled for some months after the activation of merged mining, and the block size expansion which remains scheduled for 2+ years in the future.

-----

Merge mining is implemented as a soft-fork change to the consensus rules to achieve a safer and less-disruptive deployment than the hard-fork that was used to deploy merge mining to other chains in the past: non-upgraded clients will continue to receive blocks at the point of activation with SPV security.  However the security of successive blocks will diminish as the difficulty transitions from native to auxiliary proof-of-work.  When the native difficulty reaches minimal values, there will no longer be any effective SPV protections for old nodes, and this represents a unique opportunity to deploy other non-controversial hard-fork changes to the consensus rules.

For this reason, a protocol-cleanup hard-fork is scheduled to take place after the activation of merge mining and the transition of difficulty.  As part of this cleanup, the following consensus rule changes will take effect:

1. Remove the native proof-of-work requirement entirely.  For reasons of infrastructure compatibility the block hash will still be the hash of the native header, but the hash of the header will no longer have to meet any threshold target.  This makes every winning auxiliary share a valid block without any extra work.

2. Remove the `MAX_BLOCK_SIGOPS_COST` limit.  Switching to libsecp256k1 for validation and better signature / script and transaction validation caching has made this limit nearly redundant.

3. Allow a transaction without transaction outputs.  A transaction must have input(s) to have a unique transaction ID, but it need not have outputs.  There are obscure cases when this makes sense to do (and thus forward the funds entirely as "fee" to the miner, or to process in the block-final transaction and/or coinbase in some way).

4. Do not restrict the contents of the "coinbase string" in any way, beyond the required auxiliary proof-of-work commitment.  It is currently required to be between 2 and 100 bytes in size, and must begin with the serialized block height.  The length restriction is unnecessary as miners have other means of padding transactions if they need to, and are generally incentivized not to because of miner fees.  The serialized height requirement is redundant as lock_height is also required to be set to the current block height.

5. Do not require the coinbase transaction to be final, freeing up nSequence to be used as the miner's extranonce field.  A previous soft-fork which required the coinbase's nLockTime field to be set to the medium-time-past value had the unfortunate side effect of requiring nSequence to be set to 0xffffffff since even the coinbase is checked for transaction finality.  The concept of finality makes no sense for the coinbase and this requirement is dropped after activation of the new rules, making the 4-byte nSquence field have no consensus-defined meaning, allowing it to be used as an extrnonce field.

6. Do not require zero-valued outputs to be spent by transactions with lock_height >= the coin's refheight.  This restriction is to ensure that refheights are always increasing so that demurrage is collected, not reversed.  However this argument doesn't really make sense for zero-valued outputs.  At the same time "zero-valued" outputs are increasingly likely to be used for confidential transactions or non-freicoin issued assets using extension outputs, for which the monotonic lock_height requirement is just an annoying protocol complication.

7. Do not reject "old" blocks after activation of the nVersion=2 and nVersion=3 soft-forks.  With the switch to version bits for soft-fork activation, this archaic check is shown to be rather pointless.  Rules are enforced in a block if it is downstream of the point of activation, not based on the nVersion value.  Implicitly this also restores validity of "negative" block.nVersion values.

8. Lift restrictions inside the script interpreter on maximum script size, maximum data push, maximum number of elements on the stack, and maximum number of executed opcodes.

9. Remove checks on disabled opcodes, and cause unrecognized opcodes to "return true" instead of raising an error.

10. Re-enable (and implement) certain disabled opcodes, and conspicuously missing opcodes which were never there in the first place.

Activation of the protocol-cleanup fork depends on the status of the auxpow soft-fork, and the median-time-past of the tip relative to a consensus parameter.

-----

To achieve desired scaling limits, the forward blocks architecture will eventually trigger a hard-fork modification of the consensus rules, for the primary purpose of dropping enforcement of many aggregate block limits so as to allow larger blocks on the compatibility chain.

This hard-fork will not activate until it is absolutely necessary for it to do so, at the point when real demand for additional shard space in aggregate across all forward block shard-chains exceeds the available space in the compatibility chain.  It is anticipated that this will not occur until many, many years into the future, when Freicoin/Tradecraft's usage exceeds even the levels of bitcoin usage ca. 2018.  However when it does eventually trigger, any node enforcing the old rules will be left behind.

Since the rule changes for forward blocks have not been written yet and because this flag-day code doesn't know how to detect actual activation, we cannot have older clients enforce the new rules.  What is done instead is that any rule which we anticipate changing becomes simply unenforced after this activation time, and aggregate limits are set to the maximum values the software is able to support.  After the flag-day, older clients of at least version 13.2.4 will continue to receive blocks, but with only SPV security ("trust the most work") for the new protocol rules.  So starting with the release of 13.2.4, activation of forward blocks' new scaling limits becomes a soft-fork, with the only concern being the forking off of older nodes upon activation.

The primary rules which must be altered for forward blocks scaling are:

1. Significant relaxation of the rules regarding per-block auxiliary difficulty adjustment, to allow adjustments of +/- 2x within eleven blocks, without regard of a target interval.  Forward blocks may have a new difficulty adjustment algorithm that has yet to be determined, and might include targeting a variable inter-block time to achieve compatibility chain scalability.

2. Increase of the maximum block size.  Uncapping the block size is not possible because even if the explicit limit is removed there are still implicit network and disk protocol limits that would prevent a client from syncing a chain with larger blocks.  But these network and disk limits could be set much higher than the current limits based on a 1 megabyte MAX_BASE_BLOCK_SIZE / 4 megaweight MAX_BLOCK_WEIGHT.

3. Allow larger transactions, up to the new, larger maximum block size limit in size.  This is less safe than increasing the block size since most of the nonlinear validation costs are quadratic in transaction size.  But there is research to be done in choosing what new limits should be used, and in the mean time keeping transactions only limited by the (new) block size permits flexibility in that future choice.

4. Reduce coinbase maturity to 1 block.  Once forward blocks has activated, coinbase maturity is an unnecessary delay to processing the coinbase payout queue.  It must be at least 1 to prevent miners from issuing themselves excess funds for the duration of 1 block.

Since we don't know when forward blocks will be deployed and activated, we schedule these rule changes to occur at the end of the support window for each client release, which is typically 2 years.  Each new release pushes back this activation date, and since the new rules are a relaxation of the old rules older clients will remain compatible so long as a majority of miners have upgrade and thereby pushed back their activation dates.  When forward blocks is finally deployed and activated, it will schedule its own modified rule relaxation to occur after the most distant flag day.