### PR TITLE
[MergeMining] Set auxpow difficulty to half native difficulty on activation.

### DIFF
--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -279,7 +279,7 @@ CBlockTemplate* BlockAssembler::CreateNewBlock(const CScript& scriptPubKeyIn)
 
         // Set difficulty for the auxiliary proof-of-work.
         pblock->SetFilteredTime(GetFilteredTimeAux(pindexPrev, chainparams.GetConsensus()));
-        pblock->m_aux_pow.m_commit_bits = CalculateNextWorkRequiredAux(pindexPrev, chainparams.GetConsensus());;
+        pblock->m_aux_pow.m_commit_bits = GetNextWorkRequiredAux(pindexPrev, *pblock, chainparams.GetConsensus());;
 
         // Setup the auxiliary header fields to have reasonable values.
         pblock->m_aux_pow.m_aux_version = VERSIONBITS_TOP_BITS;

--- a/src/pow.cpp
+++ b/src/pow.cpp
@@ -302,6 +302,15 @@ std::pair<int64_t, int64_t> GetAdjustmentFactorAux(const CBlockIndex* pindexLast
 
 uint32_t GetNextWorkRequiredAux(const CBlockIndex* pindexLast, const CBlockHeader& block, const Consensus::Params& params)
 {
+    // The very first block to have an auxiliary proof-of-work starts
+    // with 50% the native difficulty.
+    if (!pindexLast || pindexLast->m_aux_pow.IsNull()) {
+        arith_uint256 target;
+        target.SetCompact(block.nBits);
+        target <<= 1;
+        return target.GetCompact();
+    }
+
     return CalculateNextWorkRequiredAux(pindexLast, params);
 }
 
@@ -309,11 +318,6 @@ uint32_t CalculateNextWorkRequiredAux(const CBlockIndex* pindexLast, const Conse
 {
     arith_uint256 pow_limit = UintToArith256(params.aux_pow_limit);
 
-    // The very first block to have an auxiliary proof-of-work starts with a
-    // minimal difficulty.
-    if (!pindexLast || pindexLast->m_aux_pow.IsNull()) {
-        return pow_limit.GetCompact();
-    }
     if (params.fPowNoRetargeting) {
         return pindexLast->m_aux_pow.m_commit_bits;
     }


### PR DESCRIPTION
The first block with an auxiliary proof-of-work should have the auxpow set to the difficulty necessary to have 15 minute blocks from the get-go, in order to minimize the length of the transition period. Since we settled on 15 minute auxiliary block times, this is really easy to calculate: shift the native target to the left by 1 bit.

The code for this is rather trivial to review. I'm currently deploying it to testnet, which will cause a historical fork but allow us to demonstrate the stability of this faster transition mechanism.