### PR TITLE
Report invalid nTime-rolling to the main log, not the stratum log

### DIFF
--- a/src/stratum.cpp
+++ b/src/stratum.cpp
@@ -615,7 +615,7 @@ bool SubmitBlock(StratumClient& client, const uint256& job_id, const StratumWork
         }
 
         if (!current_work.GetBlock().m_aux_pow.IsNull() && nTime != current_work.GetBlock().nTime) {
-            LogPrint("stratum", strprintf("Error: miner %s returned altered nTime value for native proof-of-work; nTime-rolling is not supported\n", client.m_addr.ToString()).data());
+            LogPrintf("Error: miner %s returned altered nTime value for native proof-of-work; nTime-rolling is not supported\n", client.m_addr.ToString());
             throw JSONRPCError(RPC_INVALID_PARAMETER, "nTime-rolling is not supported");
         }
 


### PR DESCRIPTION
After activation of merge-mining, nTime-rolling on the native chain is no longer allowed. Miners should be configured to not use stratum's time rolling feature when mining the native proof-of-work header.  Any invalid shares which used nTime-rolling should be reported to the log so that the user is aware of the misconfiguration and the reason for the rejected shares.

The mining server was previously reporting this error, but only when `-debug=stratum` was set, which also generated a ton of stratum protocol status messages to sort through. This fix makes the error reported to the main log.