### PR TITLE
Add auxiliary subscription capability, for bitcoin merge-mining

### DIFF
--- a/MPL-2.0.txt
+++ b/MPL-2.0.txt
@@ -1,0 +1,373 @@
+Mozilla Public License Version 2.0
+==================================
+
+1. Definitions
+--------------
+
+1.1. "Contributor"
+    means each individual or legal entity that creates, contributes to
+    the creation of, or owns Covered Software.
+
+1.2. "Contributor Version"
+    means the combination of the Contributions of others (if any) used
+    by a Contributor and that particular Contributor's Contribution.
+
+1.3. "Contribution"
+    means Covered Software of a particular Contributor.
+
+1.4. "Covered Software"
+    means Source Code Form to which the initial Contributor has attached
+    the notice in Exhibit A, the Executable Form of such Source Code
+    Form, and Modifications of such Source Code Form, in each case
+    including portions thereof.
+
+1.5. "Incompatible With Secondary Licenses"
+    means
+
+    (a) that the initial Contributor has attached the notice described
+        in Exhibit B to the Covered Software; or
+
+    (b) that the Covered Software was made available under the terms of
+        version 1.1 or earlier of the License, but not also under the
+        terms of a Secondary License.
+
+1.6. "Executable Form"
+    means any form of the work other than Source Code Form.
+
+1.7. "Larger Work"
+    means a work that combines Covered Software with other material, in
+    a separate file or files, that is not Covered Software.
+
+1.8. "License"
+    means this document.
+
+1.9. "Licensable"
+    means having the right to grant, to the maximum extent possible,
+    whether at the time of the initial grant or subsequently, any and
+    all of the rights conveyed by this License.
+
+1.10. "Modifications"
+    means any of the following:
+
+    (a) any file in Source Code Form that results from an addition to,
+        deletion from, or modification of the contents of Covered
+        Software; or
+
+    (b) any new file in Source Code Form that contains any Covered
+        Software.
+
+1.11. "Patent Claims" of a Contributor
+    means any patent claim(s), including without limitation, method,
+    process, and apparatus claims, in any patent Licensable by such
+    Contributor that would be infringed, but for the grant of the
+    License, by the making, using, selling, offering for sale, having
+    made, import, or transfer of either its Contributions or its
+    Contributor Version.
+
+1.12. "Secondary License"
+    means either the GNU General Public License, Version 2.0, the GNU
+    Lesser General Public License, Version 2.1, the GNU Affero General
+    Public License, Version 3.0, or any later versions of those
+    licenses.
+
+1.13. "Source Code Form"
+    means the form of the work preferred for making modifications.
+
+1.14. "You" (or "Your")
+    means an individual or a legal entity exercising rights under this
+    License. For legal entities, "You" includes any entity that
+    controls, is controlled by, or is under common control with You. For
+    purposes of this definition, "control" means (a) the power, direct
+    or indirect, to cause the direction or management of such entity,
+    whether by contract or otherwise, or (b) ownership of more than
+    fifty percent (50%) of the outstanding shares or beneficial
+    ownership of such entity.
+
+2. License Grants and Conditions
+--------------------------------
+
+2.1. Grants
+
+Each Contributor hereby grants You a world-wide, royalty-free,
+non-exclusive license:
+
+(a) under intellectual property rights (other than patent or trademark)
+    Licensable by such Contributor to use, reproduce, make available,
+    modify, display, perform, distribute, and otherwise exploit its
+    Contributions, either on an unmodified basis, with Modifications, or
+    as part of a Larger Work; and
+
+(b) under Patent Claims of such Contributor to make, use, sell, offer
+    for sale, have made, import, and otherwise transfer either its
+    Contributions or its Contributor Version.
+
+2.2. Effective Date
+
+The licenses granted in Section 2.1 with respect to any Contribution
+become effective for each Contribution on the date the Contributor first
+distributes such Contribution.
+
+2.3. Limitations on Grant Scope
+
+The licenses granted in this Section 2 are the only rights granted under
+this License. No additional rights or licenses will be implied from the
+distribution or licensing of Covered Software under this License.
+Notwithstanding Section 2.1(b) above, no patent license is granted by a
+Contributor:
+
+(a) for any code that a Contributor has removed from Covered Software;
+    or
+
+(b) for infringements caused by: (i) Your and any other third party's
+    modifications of Covered Software, or (ii) the combination of its
+    Contributions with other software (except as part of its Contributor
+    Version); or
+
+(c) under Patent Claims infringed by Covered Software in the absence of
+    its Contributions.
+
+This License does not grant any rights in the trademarks, service marks,
+or logos of any Contributor (except as may be necessary to comply with
+the notice requirements in Section 3.4).
+
+2.4. Subsequent Licenses
+
+No Contributor makes additional grants as a result of Your choice to
+distribute the Covered Software under a subsequent version of this
+License (see Section 10.2) or under the terms of a Secondary License (if
+permitted under the terms of Section 3.3).
+
+2.5. Representation
+
+Each Contributor represents that the Contributor believes its
+Contributions are its original creation(s) or it has sufficient rights
+to grant the rights to its Contributions conveyed by this License.
+
+2.6. Fair Use
+
+This License is not intended to limit any rights You have under
+applicable copyright doctrines of fair use, fair dealing, or other
+equivalents.
+
+2.7. Conditions
+
+Sections 3.1, 3.2, 3.3, and 3.4 are conditions of the licenses granted
+in Section 2.1.
+
+3. Responsibilities
+-------------------
+
+3.1. Distribution of Source Form
+
+All distribution of Covered Software in Source Code Form, including any
+Modifications that You create or to which You contribute, must be under
+the terms of this License. You must inform recipients that the Source
+Code Form of the Covered Software is governed by the terms of this
+License, and how they can obtain a copy of this License. You may not
+attempt to alter or restrict the recipients' rights in the Source Code
+Form.
+
+3.2. Distribution of Executable Form
+
+If You distribute Covered Software in Executable Form then:
+
+(a) such Covered Software must also be made available in Source Code
+    Form, as described in Section 3.1, and You must inform recipients of
+    the Executable Form how they can obtain a copy of such Source Code
+    Form by reasonable means in a timely manner, at a charge no more
+    than the cost of distribution to the recipient; and
+
+(b) You may distribute such Executable Form under the terms of this
+    License, or sublicense it under different terms, provided that the
+    license for the Executable Form does not attempt to limit or alter
+    the recipients' rights in the Source Code Form under this License.
+
+3.3. Distribution of a Larger Work
+
+You may create and distribute a Larger Work under terms of Your choice,
+provided that You also comply with the requirements of this License for
+the Covered Software. If the Larger Work is a combination of Covered
+Software with a work governed by one or more Secondary Licenses, and the
+Covered Software is not Incompatible With Secondary Licenses, this
+License permits You to additionally distribute such Covered Software
+under the terms of such Secondary License(s), so that the recipient of
+the Larger Work may, at their option, further distribute the Covered
+Software under the terms of either this License or such Secondary
+License(s).
+
+3.4. Notices
+
+You may not remove or alter the substance of any license notices
+(including copyright notices, patent notices, disclaimers of warranty,
+or limitations of liability) contained within the Source Code Form of
+the Covered Software, except that You may alter any license notices to
+the extent required to remedy known factual inaccuracies.
+
+3.5. Application of Additional Terms
+
+You may choose to offer, and to charge a fee for, warranty, support,
+indemnity or liability obligations to one or more recipients of Covered
+Software. However, You may do so only on Your own behalf, and not on
+behalf of any Contributor. You must make it absolutely clear that any
+such warranty, support, indemnity, or liability obligation is offered by
+You alone, and You hereby agree to indemnify every Contributor for any
+liability incurred by such Contributor as a result of warranty, support,
+indemnity or liability terms You offer. You may include additional
+disclaimers of warranty and limitations of liability specific to any
+jurisdiction.
+
+4. Inability to Comply Due to Statute or Regulation
+---------------------------------------------------
+
+If it is impossible for You to comply with any of the terms of this
+License with respect to some or all of the Covered Software due to
+statute, judicial order, or regulation then You must: (a) comply with
+the terms of this License to the maximum extent possible; and (b)
+describe the limitations and the code they affect. Such description must
+be placed in a text file included with all distributions of the Covered
+Software under this License. Except to the extent prohibited by statute
+or regulation, such description must be sufficiently detailed for a
+recipient of ordinary skill to be able to understand it.
+
+5. Termination
+--------------
+
+5.1. The rights granted under this License will terminate automatically
+if You fail to comply with any of its terms. However, if You become
+compliant, then the rights granted under this License from a particular
+Contributor are reinstated (a) provisionally, unless and until such
+Contributor explicitly and finally terminates Your grants, and (b) on an
+ongoing basis, if such Contributor fails to notify You of the
+non-compliance by some reasonable means prior to 60 days after You have
+come back into compliance. Moreover, Your grants from a particular
+Contributor are reinstated on an ongoing basis if such Contributor
+notifies You of the non-compliance by some reasonable means, this is the
+first time You have received notice of non-compliance with this License
+from such Contributor, and You become compliant prior to 30 days after
+Your receipt of the notice.
+
+5.2. If You initiate litigation against any entity by asserting a patent
+infringement claim (excluding declaratory judgment actions,
+counter-claims, and cross-claims) alleging that a Contributor Version
+directly or indirectly infringes any patent, then the rights granted to
+You by any and all Contributors for the Covered Software under Section
+2.1 of this License shall terminate.
+
+5.3. In the event of termination under Sections 5.1 or 5.2 above, all
+end user license agreements (excluding distributors and resellers) which
+have been validly granted by You or Your distributors under this License
+prior to termination shall survive termination.
+
+************************************************************************
+*                                                                      *
+*  6. Disclaimer of Warranty                                           *
+*  -------------------------                                           *
+*                                                                      *
+*  Covered Software is provided under this License on an "as is"       *
+*  basis, without warranty of any kind, either expressed, implied, or  *
+*  statutory, including, without limitation, warranties that the       *
+*  Covered Software is free of defects, merchantable, fit for a        *
+*  particular purpose or non-infringing. The entire risk as to the     *
+*  quality and performance of the Covered Software is with You.        *
+*  Should any Covered Software prove defective in any respect, You     *
+*  (not any Contributor) assume the cost of any necessary servicing,   *
+*  repair, or correction. This disclaimer of warranty constitutes an   *
+*  essential part of this License. No use of any Covered Software is   *
+*  authorized under this License except under this disclaimer.         *
+*                                                                      *
+************************************************************************
+
+************************************************************************
+*                                                                      *
+*  7. Limitation of Liability                                          *
+*  --------------------------                                          *
+*                                                                      *
+*  Under no circumstances and under no legal theory, whether tort      *
+*  (including negligence), contract, or otherwise, shall any           *
+*  Contributor, or anyone who distributes Covered Software as          *
+*  permitted above, be liable to You for any direct, indirect,         *
+*  special, incidental, or consequential damages of any character      *
+*  including, without limitation, damages for lost profits, loss of    *
+*  goodwill, work stoppage, computer failure or malfunction, or any    *
+*  and all other commercial damages or losses, even if such party      *
+*  shall have been informed of the possibility of such damages. This   *
+*  limitation of liability shall not apply to liability for death or   *
+*  personal injury resulting from such party's negligence to the       *
+*  extent applicable law prohibits such limitation. Some               *
+*  jurisdictions do not allow the exclusion or limitation of           *
+*  incidental or consequential damages, so this exclusion and          *
+*  limitation may not apply to You.                                    *
+*                                                                      *
+************************************************************************
+
+8. Litigation
+-------------
+
+Any litigation relating to this License may be brought only in the
+courts of a jurisdiction where the defendant maintains its principal
+place of business and such litigation shall be governed by laws of that
+jurisdiction, without reference to its conflict-of-law provisions.
+Nothing in this Section shall prevent a party's ability to bring
+cross-claims or counter-claims.
+
+9. Miscellaneous
+----------------
+
+This License represents the complete agreement concerning the subject
+matter hereof. If any provision of this License is held to be
+unenforceable, such provision shall be reformed only to the extent
+necessary to make it enforceable. Any law or regulation which provides
+that the language of a contract shall be construed against the drafter
+shall not be used to construe this License against a Contributor.
+
+10. Versions of the License
+---------------------------
+
+10.1. New Versions
+
+Mozilla Foundation is the license steward. Except as provided in Section
+10.3, no one other than the license steward has the right to modify or
+publish new versions of this License. Each version will be given a
+distinguishing version number.
+
+10.2. Effect of New Versions
+
+You may distribute the Covered Software under the terms of the version
+of the License under which You originally received the Covered Software,
+or under the terms of any subsequent version published by the license
+steward.
+
+10.3. Modified Versions
+
+If you create software not governed by this License, and you want to
+create a new license for such software, you may create and use a
+modified version of this License if you rename the license and remove
+any references to the name of the license steward (except to note that
+such modified license differs from this License).
+
+10.4. Distributing Source Code Form that is Incompatible With Secondary
+Licenses
+
+If You choose to distribute Source Code Form that is Incompatible With
+Secondary Licenses under the terms of this version of the License, the
+notice described in Exhibit B of this License must be attached.
+
+Exhibit A - Source Code Form License Notice
+-------------------------------------------
+
+  This Source Code Form is subject to the terms of the Mozilla Public
+  License, v. 2.0. If a copy of the MPL was not distributed with this
+  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+If it is not possible or desirable to put the notice in a particular
+file, then You may include the notice in a location (such as a LICENSE
+file in a relevant directory) where a recipient would be likely to look
+for such a notice.
+
+You may add additional accurate notices of copyright ownership.
+
+Exhibit B - "Incompatible With Secondary Licenses" Notice
+---------------------------------------------------------
+
+  This Source Code Form is "Incompatible With Secondary Licenses", as
+  defined by the Mozilla Public License, v. 2.0.

--- a/src/primitives/block.cpp
+++ b/src/primitives/block.cpp
@@ -63,7 +63,7 @@ std::pair<uint256, uint256> CBlockHeader::GetAuxiliaryHash(const Consensus::Para
     // using the midstate data and commitment root hash.
     {
         CSHA256 midstate(m_aux_pow.m_midstate_hash.begin(),
-                         &m_aux_pow.m_midstate_buffer[0],
+                        &m_aux_pow.m_midstate_buffer[0],
                          m_aux_pow.m_midstate_length << 3);
         // Write the commitment root hash.
         midstate.Write(hash.begin(), 32);

--- a/src/stratum.cpp
+++ b/src/stratum.cpp
@@ -1,19 +1,7 @@
 // Copyright (c) 2020 The Freicoin Developers
-//
-// This program is free software: you can redistribute it and/or
-// modify it under the conjunctive terms of BOTH version 3 of the GNU
-// Affero General Public License as published by the Free Software
-// Foundation AND the MIT/X11 software license.
-//
-// This program is distributed in the hope that it will be useful, but
-// WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-// Affero General Public License and the MIT/X11 software license for
-// more details.
-//
-// You should have received a copy of both licenses along with this
-// program.  If not, see <https://www.gnu.org/licenses/> and
-// <http://www.opensource.org/licenses/mit-license.php>
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 #include "stratum.h"
 

--- a/src/stratum.cpp
+++ b/src/stratum.cpp
@@ -769,7 +769,7 @@ UniValue stratum_mining_submit(StratumClient& client, const UniValue& params)
     uint256 job_id = uint256S(params[1].get_str());
     if (!work_templates.count(job_id)) {
         LogPrint("stratum", "Received completed share for unknown job_id : %s\n", job_id.GetHex());
-        return true;
+        return false;
     }
     StratumWork &current_work = work_templates[job_id];
 

--- a/src/stratum.cpp
+++ b/src/stratum.cpp
@@ -958,7 +958,7 @@ static void stratum_accept_conn_cb(evconnlistener *listener, evutil_socket_t fd,
 }
 
 /** Setup the stratum connection listening services */
-bool StratumBindAddresses(event_base* base)
+static bool StratumBindAddresses(event_base* base)
 {
     int defaultPort = GetArg("-stratumport", BaseParams().StratumPort());
     std::vector<std::pair<std::string, uint16_t> > endpoints;

--- a/src/stratum.cpp
+++ b/src/stratum.cpp
@@ -54,6 +54,7 @@ struct StratumClient
     evutil_socket_t m_socket;
     bufferevent* m_bev;
     CService m_from;
+    int m_nextid;
     uint256 m_secret;
 
     CService GetPeer() const
@@ -73,8 +74,8 @@ struct StratumClient
 
     bool m_supports_extranonce;
 
-    StratumClient() : m_listener(0), m_socket(0), m_bev(0), m_authorized(false), m_mindiff(0.0), m_version_rolling_mask(0x00000000), m_last_tip(0), m_second_stage(false), m_send_work(false), m_supports_extranonce(false) { GenSecret(); }
-    StratumClient(evconnlistener* listener, evutil_socket_t socket, bufferevent* bev, CService from) : m_listener(listener), m_socket(socket), m_bev(bev), m_from(from), m_authorized(false), m_mindiff(0.0), m_version_rolling_mask(0x00000000), m_last_tip(0), m_second_stage(false), m_send_work(false), m_supports_extranonce(false) { GenSecret(); }
+    StratumClient() : m_listener(0), m_socket(0), m_bev(0), m_nextid(0), m_authorized(false), m_mindiff(0.0), m_version_rolling_mask(0x00000000), m_last_tip(0), m_second_stage(false), m_send_work(false), m_supports_extranonce(false) { GenSecret(); }
+    StratumClient(evconnlistener* listener, evutil_socket_t socket, bufferevent* bev, CService from) : m_listener(listener), m_socket(socket), m_bev(bev), m_nextid(0), m_from(from), m_authorized(false), m_mindiff(0.0), m_version_rolling_mask(0x00000000), m_last_tip(0), m_second_stage(false), m_send_work(false), m_supports_extranonce(false) { GenSecret(); }
 
     void GenSecret();
     std::vector<unsigned char> ExtraNonce1(uint256 job_id) const;
@@ -376,7 +377,7 @@ std::string GetWorkUnit(StratumClient& client)
     diff = std::max(diff, 0.001);
 
     UniValue set_difficulty(UniValue::VOBJ);
-    set_difficulty.push_back(Pair("id", NullUniValue));
+    set_difficulty.push_back(Pair("id", client.m_nextid++));
     set_difficulty.push_back(Pair("method", "mining.set_difficulty"));
     UniValue set_difficulty_params(UniValue::VARR);
     set_difficulty_params.push_back(diff);
@@ -503,7 +504,7 @@ std::string GetWorkUnit(StratumClient& client)
 
     UniValue mining_notify(UniValue::VOBJ);
     mining_notify.push_back(Pair("params", params));
-    mining_notify.push_back(Pair("id", NullUniValue));
+    mining_notify.push_back(Pair("id", client.m_nextid++));
     mining_notify.push_back(Pair("method", "mining.notify"));
 
     std::string extranonce_req;

--- a/src/stratum.cpp
+++ b/src/stratum.cpp
@@ -163,7 +163,9 @@ StratumWork::StratumWork(const CBlockTemplate& block_template, bool is_witness_e
         }
         CMutableTransaction bf(m_block_template.block.vtx.back());
         CScript& scriptPubKey = bf.vout.back().scriptPubKey;
-        assert(scriptPubKey.size() >= 37);
+        if (scriptPubKey.size() < 37) {
+            throw std::runtime_error("Expected last output of block-final transaction to have enough room for segwit commitment, but alas.");
+        }
         std::fill_n(&scriptPubKey[scriptPubKey.size()-37], 33, 0x00);
         leaves.back() = bf.GetHash();
         m_cb_wit_branch = ComputeFastMerkleBranch(leaves, 0).first;

--- a/src/stratum.cpp
+++ b/src/stratum.cpp
@@ -16,12 +16,12 @@
 #include "netbase.h"
 #include "net.h"
 #include "rpc/server.h"
-#include "util.h"
 #include "utilstrencodings.h"
 #include "serialize.h"
 #include "streams.h"
 #include "sync.h"
 #include "txmempool.h"
+#include "util.h"
 
 #include <univalue.h>
 
@@ -36,8 +36,8 @@
 
 #include <event2/event.h>
 #include <event2/listener.h>
-#include <event2/bufferevent.h>
 #include <event2/buffer.h>
+#include <event2/bufferevent.h>
 
 #include <errno.h>
 #ifdef WIN32

--- a/src/stratum.cpp
+++ b/src/stratum.cpp
@@ -138,7 +138,7 @@ StratumWork::StratumWork(const CBlockTemplate& block_template, bool is_witness_e
     // Merkle proof for the coinbase.  If segwit is active, we also use this
     // field in a different way, so we compute it in both branches.
     std::vector<uint256> leaves;
-    for (auto tx : m_block_template.block.vtx) {
+    for (const auto& tx : m_block_template.block.vtx) {
         leaves.push_back(tx.GetHash());
     }
     m_cb_branch = ComputeMerkleBranch(leaves, 0);

--- a/src/stratum.cpp
+++ b/src/stratum.cpp
@@ -764,17 +764,7 @@ UniValue stratum_mining_submit(StratumClient& client, const UniValue& params)
 {
     const std::string method("mining.submit");
     BoundParams(method, params, 5, 6);
-
-    std::string username = params[0].get_str();
-    boost::trim(username);
-
-    // There may or may not be a '+' suffix in the username, so we
-    // clean it up just in case:
-    size_t pos = username.find('+');
-    if (pos != std::string::npos) {
-        username.resize(pos);
-        boost::trim_right(username);
-    }
+    // First parameter is the client username, which is ignored.
 
     uint256 job_id = uint256S(params[1].get_str());
     if (!work_templates.count(job_id)) {

--- a/src/stratum.cpp
+++ b/src/stratum.cpp
@@ -635,7 +635,9 @@ bool SubmitBlock(StratumClient& client, const uint256& job_id, const StratumWork
         }
     }
 
-    client.m_send_work = true;
+    if (res) {
+        client.m_send_work = true;
+    }
 
     return res;
 }

--- a/src/stratum.cpp
+++ b/src/stratum.cpp
@@ -585,7 +585,9 @@ bool SubmitBlock(StratumClient& client, const uint256& job_id, const StratumWork
             new_work.GetBlock().m_aux_pow.m_aux_nonce = nNonce;
             new_work.GetBlock().m_aux_pow.m_aux_version = version;
             new_work.m_aux_hash2 = aux_hash.second;
-            assert(new_job_id == new_work.GetBlock().GetHash());
+            if (new_job_id != new_work.GetBlock().GetHash()) {
+                throw std::runtime_error("First-stage hash does not match expected value.");
+            }
             half_solved_work = new_job_id;
         } else {
             LogPrintf("NEW AUXILIARY SHARE!!! by %s: %s, %s\n", client.m_addr.ToString(), aux_hash.first.ToString(), aux_hash.second.ToString());

--- a/src/stratum.cpp
+++ b/src/stratum.cpp
@@ -545,9 +545,11 @@ bool SubmitBlock(StratumClient& client, const uint256& job_id, const StratumWork
     if (!current_work.GetBlock().m_aux_pow.IsNull() && !current_work.m_aux_hash2) {
         // Check auxiliary proof-of-work
         uint32_t version = current_work.GetBlock().m_aux_pow.m_aux_version;
-        if (nVersion) {
+        if (nVersion && client.m_version_rolling_mask) {
             version = (version & ~client.m_version_rolling_mask)
                     | (*nVersion & client.m_version_rolling_mask);
+        } else if (nVersion) {
+            version = *nVersion;
         }
 
         CMutableTransaction cb2(cb);
@@ -597,9 +599,11 @@ bool SubmitBlock(StratumClient& client, const uint256& job_id, const StratumWork
     else {
         // Check native proof-of-work
         uint32_t version = current_work.GetBlock().nVersion;
-        if (nVersion) {
+        if (nVersion && client.m_version_rolling_mask) {
             version = (version & ~client.m_version_rolling_mask)
                     | (*nVersion & client.m_version_rolling_mask);
+        } else if (nVersion) {
+            version = *nVersion;
         }
 
         if (!current_work.GetBlock().m_aux_pow.IsNull() && nTime != current_work.GetBlock().nTime) {

--- a/src/stratum.cpp
+++ b/src/stratum.cpp
@@ -1112,7 +1112,7 @@ void StopStratumServer()
 {
     LOCK(cs_stratum);
     /* Tear-down active connections. */
-    for (auto subscription : subscriptions) {
+    for (const auto& subscription : subscriptions) {
         LogPrint("stratum", "Closing stratum server connection to %s due to process termination\n", subscription.second.GetPeer().ToString());
         bufferevent_free(subscription.first);
     }

--- a/src/stratum.cpp
+++ b/src/stratum.cpp
@@ -968,7 +968,7 @@ static bool StratumBindAddresses(event_base* base)
         return false;
 
     // Bind each addresses
-    for (auto endpoint : endpoints) {
+    for (const auto& endpoint : endpoints) {
         LogPrint("stratum", "Binding stratum on address %s port %i\n", endpoint.first, endpoint.second);
         // Use CService to translate string -> sockaddr
         CService socket(CNetAddr(endpoint.first), endpoint.second);
@@ -1063,7 +1063,7 @@ bool InitStratumServer()
     }
 
     std::string strAllowed;
-    for (auto subnet : stratum_allow_subnets) {
+    for (const auto& subnet : stratum_allow_subnets) {
         strAllowed += subnet.ToString() + " ";
     }
     LogPrint("stratum", "Allowing stratum connections from: %s\n", strAllowed);
@@ -1099,7 +1099,7 @@ void InterruptStratumServer()
 {
     LOCK(cs_stratum);
     // Stop listening for connections on stratum sockets
-    for (auto binding : bound_listeners) {
+    for (const auto& binding : bound_listeners) {
         LogPrint("stratum", "Interrupting stratum service on %s\n", binding.second.ToString());
         evconnlistener_disable(binding.first);
     }
@@ -1118,7 +1118,7 @@ void StopStratumServer()
     }
     subscriptions.clear();
     /* Un-bind our listeners from their network interfaces. */
-    for (auto binding : bound_listeners) {
+    for (const auto& binding : bound_listeners) {
         LogPrint("stratum", "Removing stratum server binding on %s\n", binding.second.ToString());
         evconnlistener_free(binding.first);
     }

--- a/src/stratum.cpp
+++ b/src/stratum.cpp
@@ -683,7 +683,7 @@ UniValue stratum_mining_subscribe(StratumClient& client, const UniValue& params)
     ret.push_back(msg);
     // client.m_supports_extranonce is false, so the job_id isn't used.
     ret.push_back(HexStr(client.ExtraNonce1(uint256())));
-    ret.push_back(4); // sizeof(extranonce2)
+    ret.push_back(UniValue(4)); // sizeof(extranonce2)
 
     //ScheduleSendWork(client);
     return ret;

--- a/src/stratum.cpp
+++ b/src/stratum.cpp
@@ -72,10 +72,13 @@ struct StratumClient
     bool m_second_stage;
     bool m_send_work;
 
+    bool m_supports_aux;
+    std::set<CFreicoinAddress> m_aux_addr;
+
     bool m_supports_extranonce;
 
-    StratumClient() : m_listener(0), m_socket(0), m_bev(0), m_nextid(0), m_authorized(false), m_mindiff(0.0), m_version_rolling_mask(0x00000000), m_last_tip(0), m_second_stage(false), m_send_work(false), m_supports_extranonce(false) { GenSecret(); }
-    StratumClient(evconnlistener* listener, evutil_socket_t socket, bufferevent* bev, CService from) : m_listener(listener), m_socket(socket), m_bev(bev), m_nextid(0), m_from(from), m_authorized(false), m_mindiff(0.0), m_version_rolling_mask(0x00000000), m_last_tip(0), m_second_stage(false), m_send_work(false), m_supports_extranonce(false) { GenSecret(); }
+    StratumClient() : m_listener(0), m_socket(0), m_bev(0), m_nextid(0), m_authorized(false), m_mindiff(0.0), m_version_rolling_mask(0x00000000), m_last_tip(0), m_second_stage(false), m_send_work(false), m_supports_aux(false), m_supports_extranonce(false) { GenSecret(); }
+    StratumClient(evconnlistener* listener, evutil_socket_t socket, bufferevent* bev, CService from) : m_listener(listener), m_socket(socket), m_bev(bev), m_nextid(0), m_from(from), m_authorized(false), m_mindiff(0.0), m_version_rolling_mask(0x00000000), m_last_tip(0), m_second_stage(false), m_send_work(false), m_supports_aux(false), m_supports_extranonce(false) { GenSecret(); }
 
     void GenSecret();
     std::vector<unsigned char> ExtraNonce1(uint256 job_id) const;
@@ -241,7 +244,21 @@ uint32_t ParseHexInt4(const UniValue& hex, const std::string& name)
     return ret;
 }
 
-void CustomizeWork(const StratumClient& client, const uint256& job_id, const StratumWork& current_work, const std::vector<unsigned char>& extranonce2, CMutableTransaction& cb, CMutableTransaction& bf, std::vector<uint256>& cb_branch)
+uint256 ParseUint256(const UniValue& hex, const std::string& name)
+{
+    if (!hex.isStr()) {
+        throw std::runtime_error(name+" must be a hexidecimal string");
+    }
+    std::vector<unsigned char> vch = ParseHex(hex.get_str());
+    if (vch.size() != 32) {
+        throw std::runtime_error(name+" must be exactly 32 bytes / 64 hex");
+    }
+    uint256 ret;
+    std::copy(vch.begin(), vch.end(), ret.begin());
+    return ret;
+}
+
+void CustomizeWork(const StratumClient& client, const CFreicoinAddress& addr, const uint256& job_id, const StratumWork& current_work, const std::vector<unsigned char>& extranonce2, CMutableTransaction& cb, CMutableTransaction& bf, std::vector<uint256>& cb_branch)
 {
     cb = CMutableTransaction(current_work.GetBlock().vtx[0]);
     auto nonce = client.ExtraNonce1(job_id);
@@ -259,7 +276,7 @@ void CustomizeWork(const StratumClient& client, const uint256& job_id, const Str
     } else {
         if (cb.vout[0].scriptPubKey == (CScript() << OP_FALSE)) {
             cb.vout[0].scriptPubKey =
-                GetScriptForDestination(client.m_addr.Get());
+                GetScriptForDestination(addr.Get());
         }
     }
 
@@ -268,6 +285,32 @@ void CustomizeWork(const StratumClient& client, const uint256& job_id, const Str
         bf = CMutableTransaction(current_work.GetBlock().vtx.back());
         UpdateSegwitCommitment(current_work, cb, bf, cb_branch);
     }
+}
+
+uint256 CustomizeCommitHash(const StratumClient& client, const CFreicoinAddress& addr, const uint256& job_id, const StratumWork& current_work, const uint256& secret)
+{
+    CMutableTransaction cb, bf;
+    std::vector<uint256> cb_branch;
+    static const std::vector<unsigned char> dummy(4, 0x00); // extranonce2
+    CustomizeWork(client, addr, job_id, current_work, dummy, cb, bf, cb_branch);
+
+    CMutableTransaction cb2(cb);
+    cb2.vin[0].scriptSig = CScript();
+    cb2.vin[0].nSequence = 0;
+
+    const AuxProofOfWork& aux_pow = current_work.GetBlock().m_aux_pow;
+
+    CBlockHeader blkhdr;
+    blkhdr.nVersion = aux_pow.m_commit_version;
+    blkhdr.hashPrevBlock = current_work.GetBlock().hashPrevBlock;
+    blkhdr.hashMerkleRoot = ComputeMerkleRootFromBranch(cb2.GetHash(), cb_branch, 0);
+    blkhdr.nTime = aux_pow.m_commit_time;
+    blkhdr.nBits = aux_pow.m_commit_bits;
+    blkhdr.nNonce = aux_pow.m_commit_nonce;
+    uint256 hash = blkhdr.GetHash();
+
+    MerkleHash_Sha256Midstate(hash, hash, secret);
+    return hash;
 }
 
 std::string GetWorkUnit(StratumClient& client)
@@ -282,7 +325,7 @@ std::string GetWorkUnit(StratumClient& client)
         throw JSONRPCError(RPC_CLIENT_IN_INITIAL_DOWNLOAD, "Freicoin is downloading blocks...");
     }
 
-    if (!client.m_authorized) {
+    if (!client.m_authorized && client.m_aux_addr.empty()) {
         throw JSONRPCError(RPC_INVALID_REQUEST, "Stratum client not authorized.  Use mining.authorize first, with a Freicoin address as the username.");
     }
 
@@ -362,6 +405,43 @@ std::string GetWorkUnit(StratumClient& client)
 
     StratumWork& current_work = work_templates[job_id];
 
+    if (client.m_supports_aux && !current_work.GetBlock().m_aux_pow.IsNull() && !current_work.m_aux_hash2 && !client.m_aux_addr.empty()) {
+        const AuxProofOfWork& aux_pow = current_work.GetBlock().m_aux_pow;
+
+        CHashWriter secret_writer(SER_GETHASH, PROTOCOL_VERSION);
+        secret_writer << aux_pow.m_secret_lo;
+        secret_writer << aux_pow.m_secret_hi;
+        uint256 secret = secret_writer.GetHash();
+
+        UniValue commits(UniValue::VOBJ);
+        for (const auto& addr : client.m_aux_addr) {
+            uint256 hash = CustomizeCommitHash(client, addr, job_id, current_work, secret);
+            commits.push_back(Pair(addr.ToString(), HexStr(hash.begin(), hash.end())));
+        }
+
+        UniValue params(UniValue::VARR);
+        params.push_back(HexStr(job_id.begin(), job_id.end()));
+        params.push_back(commits);
+
+        unsigned char bias = current_work.GetBlock().GetBias();
+        uint32_t bits = aux_pow.m_commit_bits;
+        bits += static_cast<uint32_t>(bias / 8) << 24;
+        bias = bias % 8;
+        params.push_back(HexInt4(bits));
+        params.push_back(UniValue((int)bias));
+
+        params.push_back(UniValue(client.m_last_tip != tip));
+        client.m_last_tip = tip;
+        client.m_second_stage = false;
+
+        UniValue mining_aux_notify(UniValue::VOBJ);
+        mining_aux_notify.push_back(Pair("params", params));
+        mining_aux_notify.push_back(Pair("id", client.m_nextid++));
+        mining_aux_notify.push_back(Pair("method", "mining.aux.notify"));
+
+        return mining_aux_notify.write() + '\n';
+    }
+
     CBlockIndex tmp_index;
     if (!current_work.GetBlock().m_aux_pow.IsNull() && !current_work.m_aux_hash2) {
         // Auxiliary proof-of-work difficulty
@@ -387,7 +467,7 @@ std::string GetWorkUnit(StratumClient& client)
     std::vector<uint256> cb_branch;
     {
         static const std::vector<unsigned char> dummy(4, 0x00); // extranonce2
-        CustomizeWork(client, job_id, current_work, dummy, cb, bf, cb_branch);
+        CustomizeWork(client, client.m_addr, job_id, current_work, dummy, cb, bf, cb_branch);
     }
 
     CBlockHeader blkhdr;
@@ -539,7 +619,7 @@ bool SubmitBlock(StratumClient& client, const uint256& job_id, const StratumWork
 
     CMutableTransaction cb, bf;
     std::vector<uint256> cb_branch;
-    CustomizeWork(client, job_id, current_work, extranonce2, cb, bf, cb_branch);
+    CustomizeWork(client, client.m_addr, job_id, current_work, extranonce2, cb, bf, cb_branch);
 
     bool res = false;
     if (!current_work.GetBlock().m_aux_pow.IsNull() && !current_work.m_aux_hash2) {
@@ -645,6 +725,51 @@ bool SubmitBlock(StratumClient& client, const uint256& job_id, const StratumWork
     return res;
 }
 
+bool SubmitAuxiliaryBlock(StratumClient& client, const CFreicoinAddress& addr, const uint256& job_id, const StratumWork& current_work, CBlockHeader& blkhdr)
+{
+    CMutableTransaction cb, bf;
+    std::vector<uint256> cb_branch;
+    static const std::vector<unsigned char> dummy(4, 0x00); // extranonce2
+    CustomizeWork(client, addr, job_id, current_work, dummy, cb, bf, cb_branch);
+
+    CMutableTransaction cb2(cb);
+    cb2.vin[0].scriptSig = CScript();
+    cb2.vin[0].nSequence = 0;
+
+    blkhdr.m_aux_pow.m_commit_hash_merkle_root = ComputeMerkleRootFromBranch(cb2.GetHash(), cb_branch, 0);
+
+    const Consensus::Params& params = Params().GetConsensus();
+    auto aux_hash = blkhdr.GetAuxiliaryHash(params);
+    if (!CheckAuxiliaryProofOfWork(blkhdr, params)) {
+        LogPrintf("NEW AUXILIARY SHARE!!! by %s: %s, %s\n", addr.ToString(), aux_hash.first.ToString(), aux_hash.second.ToString());
+        return false;
+    }
+
+    LogPrintf("GOT AUXILIARY BLOCK!!! by %s: %s, %s\n", addr.ToString(), aux_hash.first.ToString(), aux_hash.second.ToString());
+    blkhdr.hashMerkleRoot = ComputeMerkleRootFromBranch(cb.GetHash(), cb_branch, 0);
+
+    uint256 new_job_id = blkhdr.GetHash();
+    work_templates[new_job_id] = current_work;
+    StratumWork& new_work = work_templates[new_job_id];
+    new_work.GetBlock().vtx[0] = CTransaction(cb);
+    if (new_work.m_is_witness_enabled) {
+        new_work.GetBlock().vtx.back() = CTransaction(bf);
+    }
+    new_work.GetBlock().hashMerkleRoot = BlockMerkleRoot(new_work.GetBlock(), nullptr);
+    new_work.m_cb_branch = cb_branch;
+    new_work.GetBlock().m_aux_pow = blkhdr.m_aux_pow;
+    new_work.GetBlock().nTime = blkhdr.nTime;
+    new_work.m_aux_hash2 = aux_hash.second;
+    if (new_job_id != new_work.GetBlock().GetHash()) {
+        throw std::runtime_error("First-stage hash does not match expected value.");
+    }
+
+    half_solved_work = new_job_id;
+    client.m_send_work = true;
+
+    return false;
+}
+
 void BoundParams(const std::string& method, const UniValue& params, size_t min, size_t max)
 {
     if (params.size() < min) {
@@ -737,6 +862,72 @@ UniValue stratum_mining_authorize(StratumClient& client, const UniValue& params)
     return true;
 }
 
+UniValue stratum_mining_aux_authorize(StratumClient& client, const UniValue& params)
+{
+    const std::string method("mining.aux.authorize");
+    BoundParams(method, params, 1, 2);
+
+    std::string username = params[0].get_str();
+    boost::trim(username);
+
+    // The second parameter is the password.  We don't actually do any
+    // authorization, so we ignore the password field.
+
+    size_t pos = username.find('+');
+    if (pos != std::string::npos) {
+        // Ignore suffix.
+        username.resize(pos);
+        boost::trim_right(username);
+    }
+
+    CFreicoinAddress addr(username);
+    if (!addr.IsValid()) {
+        throw JSONRPCError(RPC_INVALID_PARAMETER, strprintf("Invalid Freicoin address: %s", username));
+    }
+    if (client.m_aux_addr.count(addr)) {
+        LogPrint("stratum", "Client with address %s is already registered for stratum miner %s\n", addr.ToString(), client.GetPeer().ToString());
+        return addr.ToString();
+    }
+
+    client.m_aux_addr.insert(addr);
+    client.m_send_work = true;
+
+    LogPrintf("Authorized client %s of stratum miner %s\n", addr.ToString(), client.GetPeer().ToString());
+
+    return addr.ToString();
+}
+
+UniValue stratum_mining_aux_deauthorize(StratumClient& client, const UniValue& params)
+{
+    const std::string method("mining.aux.deauthorize");
+    BoundParams(method, params, 1, 1);
+
+    std::string username = params[0].get_str();
+    boost::trim(username);
+
+    size_t pos = username.find('+');
+    if (pos != std::string::npos) {
+        // Ignore suffix.
+        username.resize(pos);
+        boost::trim_right(username);
+    }
+
+    CFreicoinAddress addr(username);
+    if (!addr.IsValid()) {
+        throw JSONRPCError(RPC_INVALID_PARAMETER, strprintf("Invalid Freicoin address: %s", username));
+    }
+    if (!client.m_aux_addr.count(addr)) {
+        LogPrint("stratum", "No client with address %s is currently registered for stratum miner %s\n", addr.ToString(), client.GetPeer().ToString());
+        return false;
+    }
+
+    client.m_aux_addr.erase(addr);
+
+    LogPrintf("Deauthorized client %s of stratum miner %s\n", addr.ToString(), client.GetPeer().ToString());
+
+    return true;
+}
+
 UniValue stratum_mining_configure(StratumClient& client, const UniValue& params)
 {
     const std::string method("mining.configure");
@@ -793,6 +984,135 @@ UniValue stratum_mining_submit(StratumClient& client, const UniValue& params)
     SubmitBlock(client, job_id, current_work, extranonce2, nTime, nNonce, nVersion);
 
     return true;
+}
+
+UniValue stratum_mining_aux_submit(StratumClient& client, const UniValue& params)
+{
+    const std::string method("mining.aux.submit");
+    BoundParams(method, params, 14, 14);
+
+    std::string username = params[0].get_str();
+    boost::trim(username);
+
+    size_t pos = username.find('+');
+    if (pos != std::string::npos) {
+        // Ignore suffix.
+        username.resize(pos);
+        boost::trim_right(username);
+    }
+
+    CFreicoinAddress addr(username);
+    if (!addr.IsValid()) {
+        throw JSONRPCError(RPC_INVALID_PARAMETER, strprintf("Invalid Freicoin address: %s", username));
+    }
+    if (!client.m_aux_addr.count(addr)) {
+        LogPrint("stratum", "No user with address %s is currently registered\n", addr.ToString());
+    }
+
+    uint256 job_id = ParseUint256(params[1].get_str(), "job_id");
+    if (!work_templates.count(job_id)) {
+        LogPrint("stratum", "Received completed auxiliary share for unknown job_id : %s\n", HexStr(job_id.begin(), job_id.end()));
+        return false;
+    }
+    StratumWork &current_work = work_templates[job_id];
+
+    CBlockHeader blkhdr(current_work.GetBlock());
+    AuxProofOfWork& aux_pow = blkhdr.m_aux_pow;
+
+    const UniValue& commit_branch = params[2].get_array();
+    aux_pow.m_commit_branch.clear();
+    for (int i = 0; i < commit_branch.size(); ++i) {
+        const UniValue& inner_hash_node = commit_branch[i].get_array();
+        if (inner_hash_node.size() != 2) {
+            throw JSONRPCError(RPC_INVALID_PARAMETER, "commit_branch has unexpected size; must be of the form [[int, uint256]...]");
+        }
+        int bits = inner_hash_node[0].get_int();
+        if (bits < 0 || bits > 255) {
+            throw JSONRPCError(RPC_INVALID_PARAMETER, "bits parameter within commit_branch does not fit in unsigned char");
+        }
+        uint256 hash = ParseUint256(inner_hash_node[1], "commit_branch");
+        aux_pow.m_commit_branch.emplace_back((unsigned char)bits, hash);
+    }
+    if (aux_pow.m_commit_branch.size() > MAX_AUX_POW_COMMIT_BRANCH_LENGTH) {
+        throw JSONRPCError(RPC_INVALID_PARAMETER, "auxiliary proof-of-work Merkle map path is too long");
+    }
+    size_t nbits = 0;
+    for (size_t idx = 0; idx < aux_pow.m_commit_branch.size(); ++idx) {
+        ++nbits;
+        nbits += aux_pow.m_commit_branch[idx].first;
+    }
+    if (nbits >= 256) {
+        throw JSONRPCError(RPC_INVALID_PARAMETER, "auxiliary proof-of-work Merkle map path is greater than 256 bits");
+    }
+
+    aux_pow.m_midstate_hash = ParseUint256(params[3], "midstate_hash");
+    if (!params[4].get_str().empty()) {
+        aux_pow.m_midstate_buffer = ParseHexV(params[4], "midstate_buffer");
+    }
+    if (aux_pow.m_midstate_buffer.size() >= 64) {
+        throw JSONRPCError(RPC_INVALID_PARAMETER, "auxiliary proof-of-work midstate buffer is too large");
+    }
+    int64_t midstate_length = 0;
+    try {
+        midstate_length = params[5].get_int64();
+    } catch (...) {
+        throw JSONRPCError(RPC_INVALID_PARAMETER, "midstate_length is not an integer as expected");
+    }
+    if (midstate_length < 0) {
+        throw JSONRPCError(RPC_INVALID_PARAMETER, "midstate length cannot be negative");
+    }
+    if (midstate_length >= std::numeric_limits<uint32_t>::max()) {
+        throw JSONRPCError(RPC_INVALID_PARAMETER, "non-representable midstate length for auxiliary proof-of-work");
+    }
+    aux_pow.m_midstate_length = (uint32_t)midstate_length;
+    if (aux_pow.m_midstate_buffer.size() != aux_pow.m_midstate_length % 64) {
+        throw JSONRPCError(RPC_INVALID_PARAMETER, "auxiliary proof-of-work midstate buffer doesn't match anticipated length");
+    }
+
+    aux_pow.m_aux_lock_time = ParseHexInt4(params[6], "lock_time");
+
+    const UniValue& aux_branch = params[7].get_array();
+    aux_pow.m_aux_branch.clear();
+    for (int i = 0; i < aux_branch.size(); ++i) {
+        aux_pow.m_aux_branch.push_back(ParseUint256(aux_branch[i], "aux_branch"));
+    }
+    if (aux_pow.m_aux_branch.size() > MAX_AUX_POW_BRANCH_LENGTH) {
+        throw JSONRPCError(RPC_INVALID_PARAMETER, "auxiliary proof-of-work Merkle branch is too long");
+    }
+    int64_t num_txns = params[8].get_int64();
+    if (num_txns < 1) {
+        throw JSONRPCError(RPC_INVALID_PARAMETER, "number of transactions in auxiliary block cannot be less than one");
+    }
+    if (num_txns > std::numeric_limits<uint32_t>::max()) {
+        throw JSONRPCError(RPC_INVALID_PARAMETER, "non-representable number of transactions in auxiliary block");
+    }
+    aux_pow.m_aux_num_txns = (uint32_t)num_txns;
+
+    aux_pow.m_aux_hash_prev_block = ParseUint256(params[10], "hashPrevBlock");
+    blkhdr.nTime = ParseHexInt4(params[11], "nTime");
+    aux_pow.m_aux_bits = ParseHexInt4(params[12], "nBits");
+    aux_pow.m_aux_nonce = ParseHexInt4(params[13], "nNonce");
+    aux_pow.m_aux_version = ParseHexInt4(params[9], "nVersion");
+
+    SubmitAuxiliaryBlock(client, addr, job_id, current_work, blkhdr);
+
+    return true;
+}
+
+UniValue stratum_mining_aux_subscribe(StratumClient& client, const UniValue& params)
+{
+    const std::string method("mining.aux.subscribe");
+    BoundParams(method, params, 0, 0);
+
+    client.m_supports_aux = true;
+
+    UniValue ret(UniValue::VARR);
+    const uint256& aux_pow_path = Params().GetConsensus().aux_pow_path;
+    ret.push_back(HexStr(aux_pow_path.begin(), aux_pow_path.end()));
+    ret.push_back(UniValue((int)MAX_AUX_POW_COMMIT_BRANCH_LENGTH));
+    ret.push_back(UniValue((int)MAX_AUX_POW_BRANCH_LENGTH));
+
+    return ret;
 }
 
 UniValue stratum_mining_extranonce_subscribe(StratumClient& client, const UniValue& params)
@@ -1020,7 +1340,7 @@ void BlockWatcher()
             evbuffer *output = bufferevent_get_output(bev);
             StratumClient& client = subscription.second;
             // Ignore clients that aren't authorized yet.
-            if (!client.m_authorized) {
+            if (!client.m_authorized && client.m_aux_addr.empty()) {
                 continue;
             }
             // Ignore clients that are already working on the new block.
@@ -1082,6 +1402,13 @@ bool InitStratumServer()
     stratum_method_dispatch["mining.authorize"] = stratum_mining_authorize;
     stratum_method_dispatch["mining.configure"] = stratum_mining_configure;
     stratum_method_dispatch["mining.submit"]    = stratum_mining_submit;
+    stratum_method_dispatch["mining.aux.submit"] = stratum_mining_aux_submit;
+    stratum_method_dispatch["mining.aux.authorize"] =
+        stratum_mining_aux_authorize;
+    stratum_method_dispatch["mining.aux.deauthorize"] =
+        stratum_mining_aux_deauthorize;
+    stratum_method_dispatch["mining.aux.subscribe"] =
+        stratum_mining_aux_subscribe;
     stratum_method_dispatch["mining.extranonce.subscribe"] =
         stratum_mining_extranonce_subscribe;
 

--- a/src/stratum.cpp
+++ b/src/stratum.cpp
@@ -16,12 +16,12 @@
 #include "netbase.h"
 #include "net.h"
 #include "rpc/server.h"
-#include "utilstrencodings.h"
 #include "serialize.h"
 #include "streams.h"
 #include "sync.h"
 #include "txmempool.h"
 #include "util.h"
+#include "utilstrencodings.h"
 
 #include <univalue.h>
 
@@ -270,8 +270,6 @@ void CustomizeWork(const StratumClient& client, const uint256& job_id, const Str
 
 std::string GetWorkUnit(StratumClient& client)
 {
-    using std::swap;
-
     LOCK(cs_main);
 
     if (vNodes.empty() && !Params().MineBlocksOnDemand()) {
@@ -474,7 +472,7 @@ std::string GetWorkUnit(StratumClient& client)
     uint256 hashPrevBlock(blkhdr.hashPrevBlock);
     for (int i = 0; i < 256/32; ++i) {
         ((uint32_t*)hashPrevBlock.begin())[i] = bswap_32(
-            ((uint32_t*)hashPrevBlock.begin())[i]);
+        ((uint32_t*)hashPrevBlock.begin())[i]);
     }
     std::reverse(hashPrevBlock.begin(),
                  hashPrevBlock.end());

--- a/src/stratum.cpp
+++ b/src/stratum.cpp
@@ -225,7 +225,7 @@ std::string HexInt4(uint32_t val)
     return HexStr(vch);
 }
 
-uint32_t ParseHexInt4(UniValue hex, std::string name)
+uint32_t ParseHexInt4(const UniValue& hex, const std::string& name)
 {
     std::vector<unsigned char> vch = ParseHexV(hex, name);
     if (vch.size() != 4) {
@@ -328,7 +328,7 @@ std::string GetWorkUnit(StratumClient& client)
         std::vector<uint256> old_job_ids;
         boost::optional<uint256> oldest_job_id = boost::none;
         uint32_t oldest_job_nTime = last_update_time;
-        for (auto work_template : work_templates) {
+        for (const auto& work_template : work_templates) {
             // If, for whatever reason the new work was generated with
             // an old nTime, don't erase it!
             if (work_template.first == job_id) {
@@ -346,7 +346,7 @@ std::string GetWorkUnit(StratumClient& client)
             }
         }
         // Remove all outdated work.
-        for (auto old_job_id : old_job_ids) {
+        for (const auto& old_job_id : old_job_ids) {
             work_templates.erase(old_job_id);
             LogPrint("stratum", "Removed outdated stratum block template (%d total): %s\n", work_templates.size(), old_job_id.GetHex());
         }

--- a/src/stratum.cpp
+++ b/src/stratum.cpp
@@ -497,6 +497,7 @@ std::string GetWorkUnit(StratumClient& client)
     params.push_back(UniValue((client.m_last_tip != tip)
                            || (client.m_second_stage != bool(current_work.m_aux_hash2))));
     client.m_last_tip = tip;
+    client.m_second_stage = bool(current_work.m_aux_hash2);
 
     UniValue mining_notify(UniValue::VOBJ);
     mining_notify.push_back(Pair("params", params));

--- a/src/stratum.cpp
+++ b/src/stratum.cpp
@@ -378,7 +378,7 @@ std::string GetWorkUnit(StratumClient& client)
     set_difficulty.push_back(Pair("id", client.m_nextid++));
     set_difficulty.push_back(Pair("method", "mining.set_difficulty"));
     UniValue set_difficulty_params(UniValue::VARR);
-    set_difficulty_params.push_back(diff);
+    set_difficulty_params.push_back(UniValue(diff));
     set_difficulty.push_back(Pair("params", set_difficulty_params));
 
     CMutableTransaction cb, bf;
@@ -492,8 +492,8 @@ std::string GetWorkUnit(StratumClient& client)
     params.push_back(HexInt4(blkhdr.nVersion));
     params.push_back(HexInt4(blkhdr.nBits));
     params.push_back(HexInt4(blkhdr.nTime));
-    params.push_back((client.m_last_tip != tip)
-                  || (client.m_second_stage != bool(current_work.m_aux_hash2)));
+    params.push_back(UniValue((client.m_last_tip != tip)
+                           || (client.m_second_stage != bool(current_work.m_aux_hash2))));
     client.m_last_tip = tip;
 
     UniValue mining_notify(UniValue::VOBJ);

--- a/src/stratum.h
+++ b/src/stratum.h
@@ -10,9 +10,6 @@
 
 #include <event2/event.h>
 
-/** Setup the stratum connection listening services. */
-bool StratumBindAddresses(event_base* base);
-
 /** Configure the stratum server. */
 bool InitStratumServer();
 

--- a/src/stratum.h
+++ b/src/stratum.h
@@ -1,19 +1,7 @@
 // Copyright (c) 2020 The Freicoin Developers
-//
-// This program is free software: you can redistribute it and/or
-// modify it under the conjunctive terms of BOTH version 3 of the GNU
-// Affero General Public License as published by the Free Software
-// Foundation AND the MIT/X11 software license.
-//
-// This program is distributed in the hope that it will be useful, but
-// WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-// Affero General Public License and the MIT/X11 software license for
-// more details.
-//
-// You should have received a copy of both licenses along with this
-// program.  If not, see <https://www.gnu.org/licenses/> and
-// <http://www.opensource.org/licenses/mit-license.php>
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 #ifndef FREICOIN_STRATUM_H
 #define FREICOIN_STRATUM_H


### PR DESCRIPTION
This pull request accomplishes a couple of tasks:

- Relicense the stratum subsystem under the terms of the Mozilla Public License 2.0, which allows it to be extracted and used in Bitcoin Core without engaging the GPL's viral clauses.  This is, in principle, something that is not to be done lightly, since those GPL clauses protect the rights of users.  However in this instance I, the sole author of the stratum subsystem, deemed that the presumed greater adoption of merged mining benefits all to a larger degree.
- Add auxiliary work registration to the stratum mining subsystem.  This allows a single stratum connection to be used for connecting the auxiliary chain (bitcoind) to the freicoin miner, and for multiplexing multiple mining users along that connection. Auxiliary commitments are compactly served to the upstream miner, while still reporting second-stage work units as needed.
- Allow the specification of `extranonce1` and an unconstrained `nVersion` on submission, since the merge-mined chain has little control over what extranonce and version bits are set by the upstream miner.
- A large number of small fixes to the stratum mining subsystem to improve performance, stability, and logging.

Once merged, this PR adds sufficient capability to serve work to upstream merge-mining servers implemented in Bitcoin Core. There will be a separate PR to add this capability to the `bitcoin-merge-mining-13` and later branches of the tradecraft repository.